### PR TITLE
Feature/aggregations: moe and weighted avg

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,8 +10,8 @@ serve-debug:
 serve-release-debug:
     watchexec -r -s SIGKILL 'cargo build --release && RUST_LOG=debug ./target/release/tesseract'
 
-deploy host:
-    cargo build --release && scp target/release/tesseract {{host}}:~/.
+deploy to:
+    cargo build --release && scp target/release/tesseract {{to}}
 
 check:
     watchexec cargo check

--- a/moe.md
+++ b/moe.md
@@ -1,0 +1,116 @@
+Moe (not approximated), for pums
+
+Setup was the same as for weighted avg, just rename the cols val and weight to val1 and val2
+
+The general equation is
+```
+1.645 * pow(0.05 * (pow(sum(val1) - sum(val2), 2) + pow(sum(val1) - sum(val3), 2) + ...), 2)
+```
+
+For the calculation, I'll need to specify the primary value, and then all the secondary values in a list.
+
+This is easier than the approx moe, because I only need to pass through many cols, instead of doing two different drilldown patterns on the value.
+This strategy is also similar to the weighted avg calculation, where there's an intermediate aggregation (sum) on the fact table, and then the final calculation is done at the end after dim table joins.
+The concern is whether the performance is adequate. I should generate a statement to test it against a full dataset.
+
+Setup:
+```
+mochi :) create table test_weighted (id Int32, val Int32, weight Int32) Engine=MergeTree() Order By id;
+mochi :) insert into test_weighted (id, val, weight) values (1,1, 1100), (2,2, 1200), (3,3, 1300), (4,4, 1400), (1, 5, 1500), (2,6, 1600), (3,7, 1700), (4,8, 1800)
+mochi :) create table test_weighted_dim (id Int32, label String, group_id Int32, group_label String) Engine=MergeTree() Order By id;
+mochi :) insert into test_weighted_dim (id, label, group_id, group_label) values (1, 'state1', 1, 'country1'), (2, 'state2', 1, 'country1'), (3, 'state3', 2, 'country2'), (4,'state4', 2, 'country2')
+```
+Moe with no intermediate aggregation
+```
+mochi :) select group_id, group_label, 1.645 * pow(0.05 * (pow(sum(val1) - sum(val2), 2)), 0.5) from (select id, label, group_id, group_label, val1, val2 from (select id, label, group_id, group_label from test_weighted_dim) all inner join (select id,  val as val1, weight as val2 from test_weighted) using id) group by group_id, group_label
+
+SELECT 
+    group_id, 
+    group_label, 
+    1.645 * pow(0.05 * pow(sum(val1) - sum(val2), 2), 0.5)
+FROM 
+(
+    SELECT 
+        id, 
+        label, 
+        group_id, 
+        group_label, 
+        val1, 
+        val2
+    FROM 
+    (
+        SELECT 
+            id, 
+            label, 
+            group_id, 
+            group_label
+        FROM test_weighted_dim 
+    ) 
+    ALL INNER JOIN 
+    (
+        SELECT 
+            id, 
+            val AS val1, 
+            weight AS val2
+        FROM test_weighted 
+    ) USING (id)
+) 
+GROUP BY 
+    group_id, 
+    group_label
+
+┌─group_id─┬─group_label─┬─multiply(1.645, pow(multiply(0.05, pow(minus(sum(val1), sum(val2)), 2)), 0.5))─┐
+│        2 │ country2    │                                                              2272.473400241464 │
+│        1 │ country1    │                                                             1981.1495198608811 │
+└──────────┴─────────────┴────────────────────────────────────────────────────────────────────────────────┘
+
+2 rows in set. Elapsed: 0.005 sec. 
+```
+
+Moe with intermediate aggregation
+```
+mochi :) select group_id, group_label, 1.645 * pow(0.05 * (pow(sum(val1_sum) - sum(val2_sum), 2)), 0.5) from (select id, label, group_id, group_label, val1_sum, val2_sum from (select id, label, group_id, group_label from test_weighted_dim) all inner join (select id,  sum(val) as val1_sum, sum(weight) as val2_sum from test_weighted group by id) using id) group by group_id, group_label
+
+SELECT 
+    group_id, 
+    group_label, 
+    1.645 * pow(0.05 * pow(sum(val1_sum) - sum(val2_sum), 2), 0.5)
+FROM 
+(
+    SELECT 
+        id, 
+        label, 
+        group_id, 
+        group_label, 
+        val1_sum, 
+        val2_sum
+    FROM 
+    (
+        SELECT 
+            id, 
+            label, 
+            group_id, 
+            group_label
+        FROM test_weighted_dim 
+    ) 
+    ALL INNER JOIN 
+    (
+        SELECT 
+            id, 
+            sum(val) AS val1_sum, 
+            sum(weight) AS val2_sum
+        FROM test_weighted 
+        GROUP BY id
+    ) USING (id)
+) 
+GROUP BY 
+    group_id, 
+    group_label
+
+┌─group_id─┬─group_label─┬─multiply(1.645, pow(multiply(0.05, pow(minus(sum(val1_sum), sum(val2_sum)), 2)), 0.5))─┐
+│        2 │ country2    │                                                                      2272.473400241464 │
+│        1 │ country1    │                                                                     1981.1495198608811 │
+└──────────┴─────────────┴────────────────────────────────────────────────────────────────────────────────────────┘
+
+2 rows in set. Elapsed: 0.004 sec. 
+```

--- a/moe.md
+++ b/moe.md
@@ -4,7 +4,7 @@ Setup was the same as for weighted avg, just rename the cols val and weight to v
 
 The general equation is
 ```
-1.645 * pow(0.05 * (pow(sum(val1) - sum(val2), 2) + pow(sum(val1) - sum(val3), 2) + ...), 2)
+1.645 * pow(0.05 * (pow(sum(val1) - sum(val2), 2) + pow(sum(val1) - sum(val3), 2) + ...), 0.5)
 ```
 
 For the calculation, I'll need to specify the primary value, and then all the secondary values in a list.

--- a/tesseract-clickhouse/src/lib.rs
+++ b/tesseract-clickhouse/src/lib.rs
@@ -2,7 +2,7 @@ use clickhouse_rs::Pool;
 use clickhouse_rs::types::Options;
 use failure::Error;
 use futures::future::Future;
-use log::{debug, info};
+use log::*;
 use std::time::{Duration, Instant};
 use tesseract_core::{Backend, DataFrame, QueryIr};
 

--- a/tesseract-clickhouse/src/sql.rs
+++ b/tesseract-clickhouse/src/sql.rs
@@ -1,3 +1,4 @@
+mod aggregator;
 mod growth;
 mod options;
 mod primary_agg;

--- a/tesseract-clickhouse/src/sql/aggregator.rs
+++ b/tesseract-clickhouse/src/sql/aggregator.rs
@@ -1,0 +1,14 @@
+use tesseract_core::Aggregator;
+
+pub fn agg_sql_string(col: &str, aggregator: &Aggregator) -> String {
+    match aggregator {
+        Aggregator::Sum => format!("sum({})", col),
+        Aggregator::Average => format!("avg({})", col),
+        Aggregator::Median => format!("median({})", col),
+        // TODO impl this
+        Aggregator::WeightedAverage => format!("avg({})", col),
+        Aggregator::Moe => format!("sqrt(sum(power({} / 1.645, 2))) * 1.645", col),
+        // TODO uses find and replace; the placeholder is {}
+        Aggregator::Custom(s) => format!("{}{}", s, col),
+    }
+}

--- a/tesseract-clickhouse/src/sql/aggregator.rs
+++ b/tesseract-clickhouse/src/sql/aggregator.rs
@@ -1,6 +1,9 @@
+use log::*;
 use tesseract_core::Aggregator;
 
 pub fn agg_sql_string(col: &str, aggregator: &Aggregator) -> String {
+    info!("{:?}", aggregator);
+
     match aggregator {
         Aggregator::Sum => format!("sum({})", col),
         Aggregator::Average => format!("avg({})", col),

--- a/tesseract-clickhouse/src/sql/aggregator.rs
+++ b/tesseract-clickhouse/src/sql/aggregator.rs
@@ -12,6 +12,6 @@ pub fn agg_sql_string(col: &str, aggregator: &Aggregator) -> String {
         Aggregator::WeightedAverage => format!("avg({})", col),
         Aggregator::Moe => format!("sqrt(sum(power({} / 1.645, 2))) * 1.645", col),
         // TODO uses find and replace; the placeholder is {}
-        Aggregator::Custom(s) => format!("{}{}", s, col),
+        Aggregator::Custom(s) => s.replace("{}", col),
     }
 }

--- a/tesseract-clickhouse/src/sql/aggregator.rs
+++ b/tesseract-clickhouse/src/sql/aggregator.rs
@@ -1,17 +1,133 @@
+//! Applying aggregates to measures
+//!
+//! This is a little complex, because some formulas are complex.
+//!
+//! for performance reasons, there's an aggregation at the fact table scan level,
+//! and then a second aggregation when rolling up to a parent level.
+//!
+//! This works great for simple aggregations like sum, doing it in two parts doesn't
+//! affect the aggregation.
+//!
+//! However, for more complex formulas like median, weighted avg, and moe, applying the
+//! full formula to the first pass loses information needed for the second pass.
+//!
+//! Therefore, I've hardcoded weighted avg and moe so that the sums are done in the first
+//! pass, but then the formula is applied at the second pass.
+//!
+//! median is not yet implemented. Custom is halfway implemented, but will need some guardrails.
+
 use log::*;
+use itertools::join;
 use tesseract_core::Aggregator;
 
-pub fn agg_sql_string(col: &str, aggregator: &Aggregator) -> String {
+/// First pass for aggregator
+/// This is called only when doing aggregations on the fact table.
+/// For more complex aggregations like weighted average and moe, some component
+/// parts are aggregated here, but the equation (with divisions or other complex
+/// arithmetic) are not called until the final pass
+pub fn agg_sql_string_pass_1(col: &str, aggregator: &Aggregator, mea_idx: usize) -> String {
     info!("{:?}", aggregator);
 
     match aggregator {
-        Aggregator::Sum => format!("sum({})", col),
-        Aggregator::Average => format!("avg({})", col),
-        Aggregator::Median => format!("median({})", col),
-        // TODO impl this
-        Aggregator::WeightedAverage => format!("avg({})", col),
-        Aggregator::Moe => format!("sqrt(sum(power({} / 1.645, 2))) * 1.645", col),
-        // TODO uses find and replace; the placeholder is {}
-        Aggregator::Custom(s) => s.replace("{}", col),
+        Aggregator::Sum => format!("sum({}) as m{}", col, mea_idx),
+        Aggregator::Average => format!("avg({}) as m{}", col, mea_idx),
+        Aggregator::Median => format!("median({}) as m{}", col, mea_idx),
+        Aggregator::WeightedAverage { weight_column } => {
+            format!("sum({0} * {1}) as m{2}_weighted_avg_num, sum({1}) as m{2}_weighted_avg_denom",
+                col,
+                weight_column,
+                mea_idx,
+            )
+        },
+        Aggregator::Moe { secondary_columns }=> {
+            let secondaries = secondary_columns.iter().enumerate()
+                .map(|(n, col)| {
+                    format!("sum({}) as m{}_moe_secondary_{}", col, mea_idx, n)
+                });
+
+            format!("{} as m{}_moe_primary, {}",
+                col,
+                mea_idx,
+                join(secondaries, ", "),
+            )
+        },
+        Aggregator::Custom(s) => {
+            let custom = s.replace("{}", col);
+            format!("{} as m{}", custom, mea_idx)
+        },
+    }
+}
+
+// this is used to select mea cols as they bubble up from the fact subquery through
+// each subquery join
+pub fn agg_sql_string_select_mea(aggregator: &Aggregator, mea_idx: usize) -> String {
+    match aggregator {
+        Aggregator::Sum => format!("m{0}", mea_idx),
+        Aggregator::Average => format!("m{0}", mea_idx),
+        Aggregator::Median => format!("m{0}", mea_idx),
+        Aggregator::WeightedAverage { weight_column } => {
+            format!("m{0}_weighted_avg_num), sum(m{0}_weighted_avg_denom)",
+                mea_idx,
+            )
+        },
+        Aggregator::Moe { secondary_columns }=> {
+            let secondaries = secondary_columns.iter().enumerate()
+                .map(|(n, _)| {
+                    format!("m{}_moe_secondary_{}", mea_idx, n)
+                });
+
+            format!("m{}_moe_primary, {}",
+                mea_idx,
+                join(secondaries, ", "),
+            )
+        },
+        Aggregator::Custom(_) => format!("m{}", mea_idx),
+    }
+}
+
+/// computes final formula for aggregates after all joins
+/// For simple aggregates, can just apply the fn and add alias
+///
+/// For more complex aggregations, the full formula an be applied at this level
+pub fn agg_sql_string_pass_2(aggregator: &Aggregator, mea_idx: usize) -> String {
+    info!("{:?}", aggregator);
+
+    match aggregator {
+        Aggregator::Sum => format!("sum(m{0}) as final_m{0}", mea_idx),
+        Aggregator::Average => format!("avg(m{0}) as final_m{0}", mea_idx),
+        Aggregator::Median => format!("median(m{0}) as final_m{0}", mea_idx),
+        Aggregator::WeightedAverage { weight_column } => {
+            format!("(sum(m{0}_weighted_avg_num) / sum(m{0}_weighted_avg_denom)) as final_m{0}",
+                mea_idx,
+            )
+        },
+        Aggregator::Moe { secondary_columns }=> {
+            let inner_seq = secondary_columns.iter().enumerate()
+                .map(|(n, _)| {
+                    format!("pow(sum(m{0}_moe_primary) - sum(m{0}_moe_secondary_{1}), 2)",
+                        mea_idx,
+                        n,
+                    )
+                });
+            let inner_seq = join(inner_seq, " + ");
+
+            format!("1.645 * sqrt(0.05 * ({}))",
+                inner_seq,
+            )
+        },
+        Aggregator::Custom(s) => {
+            let custom = s.replace("{}", &format!("m{}", mea_idx));
+            format!("{} as m{}", custom, mea_idx)
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn pass_1_basic() {
+        panic!()
     }
 }

--- a/tesseract-clickhouse/src/sql/growth.rs
+++ b/tesseract-clickhouse/src/sql/growth.rs
@@ -156,11 +156,15 @@ mod test {
     use super::*;
     use super::super::*;
 
+    use tesseract_core::Table;
+    use tesseract_core::query_ir::LevelColumn;
+
     #[test]
     fn test_growth() {
         let (growth, _headers) = calculate("select * from test".to_owned(), "date, language, framework, ex_complete", 1,
             &GrowthSql {
                 time_drill: DrilldownSql {
+                    alias_postfix: "".into(),
                     table: Table { name: "".to_owned(), primary_key: None, schema: None },
                     primary_key: "".to_owned(),
                     foreign_key: "".to_owned(),

--- a/tesseract-clickhouse/src/sql/primary_agg.rs
+++ b/tesseract-clickhouse/src/sql/primary_agg.rs
@@ -1,5 +1,6 @@
 use itertools::join;
 
+use super::aggregator::agg_sql_string;
 use super::{
     TableSql,
     CutSql,
@@ -91,7 +92,7 @@ pub fn primary_agg(
     let mea_cols = meas
         .iter()
         .enumerate()
-        .map(|(i, m)| format!("{} as m{}", m.agg_col_string(), i));
+        .map(|(i, m)| format!("{} as m{}", agg_sql_string(&m.column, &m.aggregator), i));
     let mea_cols = join(mea_cols, ", ");
 
     let inline_dim_cols = inline_drills.iter().map(|d| d.col_alias_string());
@@ -172,7 +173,13 @@ pub fn primary_agg(
     let final_drill_cols = drills.iter().map(|drill| drill.col_alias_only_string());
     let final_drill_cols = join(final_drill_cols, ", ");
 
-    let final_mea_cols = meas.iter().enumerate().map(|(i, mea)| format!("{}(m{}) as final_m{}", mea.aggregator, i, i));
+    let final_mea_cols = meas.iter().enumerate().map(|(i, mea)| {
+            let col = format!("m{}", i);
+            format!("{} as final_m{}",
+                agg_sql_string(&col, &mea.aggregator),
+                i,
+            )
+        });
     let final_mea_cols = join(final_mea_cols, ", ");
 
     // This is the final result of the groupings.

--- a/tesseract-clickhouse/src/sql/primary_agg.rs
+++ b/tesseract-clickhouse/src/sql/primary_agg.rs
@@ -1,6 +1,10 @@
 use itertools::join;
 
-use super::aggregator::agg_sql_string;
+use super::aggregator::{
+    agg_sql_string_pass_1,
+    agg_sql_string_pass_2,
+    agg_sql_string_select_mea,
+};
 use super::{
     TableSql,
     CutSql,
@@ -92,7 +96,11 @@ pub fn primary_agg(
     let mea_cols = meas
         .iter()
         .enumerate()
-        .map(|(i, m)| format!("{} as m{}", agg_sql_string(&m.column, &m.aggregator), i));
+        .map(|(i, m)| {
+            // should return "m.aggregator({m.col}) as m{i}" for simple cases
+            agg_sql_string_pass_1(&m.column, &m.aggregator, i)
+        }
+        );
     let mea_cols = join(mea_cols, ", ");
 
     let inline_dim_cols = inline_drills.iter().map(|d| d.col_alias_string());
@@ -146,6 +154,17 @@ pub fn primary_agg(
     // initialize current dim cols with inline drills and idx cols (all dim cols)
     let mut current_dim_cols = vec![all_fact_dim_aliass];
 
+    // Create sql string for the measures that are carried up from the
+    // fact table query
+    let select_mea_cols = meas
+        .iter()
+        .enumerate()
+        .map(|(i, m)| {
+            // should return "m{i}" for simple cases
+            agg_sql_string_select_mea(&m.aggregator, i)
+        });
+    let select_mea_cols = join(select_mea_cols, ", ");
+
     for dim_subquery in dim_subqueries {
         // This section needed to accumulate the dim cols that are being selected over
         // the recursive joins.
@@ -162,7 +181,7 @@ pub fn primary_agg(
         // Now construct subquery
         sub_queries = format!("select {}{} from ({}) all right join ({}) using {}",
             sub_queries_dim_cols,
-            join((0..meas.len()).map(|i| format!("m{}", i)), ", "),
+            select_mea_cols,
             dim_subquery.sql,
             sub_queries,
             dim_subquery.foreign_key
@@ -174,11 +193,8 @@ pub fn primary_agg(
     let final_drill_cols = join(final_drill_cols, ", ");
 
     let final_mea_cols = meas.iter().enumerate().map(|(i, mea)| {
-            let col = format!("m{}", i);
-            format!("{} as final_m{}",
-                agg_sql_string(&col, &mea.aggregator),
-                i,
-            )
+            // should return "m.aggregator(m{i}) as final_m{i}" for simple cases
+            agg_sql_string_pass_2(&mea.aggregator, i)
         });
     let final_mea_cols = join(final_mea_cols, ", ");
 

--- a/tesseract-clickhouse/src/sql/rca.rs
+++ b/tesseract-clickhouse/src/sql/rca.rs
@@ -283,8 +283,10 @@ pub fn calculate(
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use super::super::*;
+
+    use tesseract_core::Table;
+    use tesseract_core::query_ir::LevelColumn;
 
     #[test]
     fn test_rca_sql() {
@@ -349,6 +351,7 @@ mod test {
         //];
 
         let drill_1 = vec![DrilldownSql {
+            alias_postfix: "".into(),
             foreign_key: "date_id".into(),
             primary_key: "date_id".into(),
             table: Table { name: "sales".into(), schema: None, primary_key: None },
@@ -370,6 +373,7 @@ mod test {
         }];
 
         let drill_2 = vec![DrilldownSql {
+            alias_postfix: "".into(),
             foreign_key: "product_id".into(),
             primary_key: "product_id".into(),
             table: Table { name: "dim_products".into(), schema: None, primary_key: None },
@@ -386,16 +390,20 @@ mod test {
             property_columns: vec![],
         }];
 
-        let mea = MeasureSql { aggregator: "sum".into(), column: "quantity".into() };
+        use tesseract_core::schema::aggregator::Aggregator;
+        let mea = MeasureSql { aggregator: Aggregator::Sum, column: "quantity".into() };
+
+        let debug = false;
 
         let rca = RcaSql {
+            debug,
             drill_1,
             drill_2,
             mea,
         };
 
         assert_eq!(
-            clickhouse_sql(&table, &[], &[], &[], &None, &None, &None, &Some(rca), &None),
+            clickhouse_sql(&table, &[], &[], &[], &None, &None, &None, &None, &Some(rca), &None),
             "".to_owned()
         );
     }

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -2,7 +2,7 @@ mod backend;
 mod dataframe;
 pub mod format;
 pub mod names;
-mod schema;
+pub mod schema;
 mod sql;
 pub mod query;
 pub mod query_ir;

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -24,7 +24,7 @@ use self::names::{
     Property,
     LevelName,
 };
-pub use self::schema::{Schema, Cube, Table};
+pub use self::schema::{Schema, Cube, Table, Aggregator};
 use self::query_ir::{
     CutSql,
     DrilldownSql,

--- a/tesseract-core/src/query_ir.rs
+++ b/tesseract-core/src/query_ir.rs
@@ -3,6 +3,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use crate::query::{LimitQuery, SortDirection, Constraint};
 use crate::schema::Table;
+use crate::schema::aggregator::Aggregator;
 
 pub struct QueryIr {
     pub table: TableSql,
@@ -202,15 +203,17 @@ pub enum MemberType {
 
 #[derive(Debug, Clone)]
 pub struct MeasureSql {
-    pub aggregator: String,
+    pub aggregator: Aggregator,
     pub column: String,
 }
 
-impl MeasureSql {
-    pub fn agg_col_string(&self) -> String {
-        format!("{}({})", self.aggregator, self.column)
-    }
-}
+// NOTE: This is now specific to each db, because of the custom aggregators
+// e.g. median
+//impl MeasureSql {
+//    pub fn agg_col_string(&self) -> String {
+//        format!("{}({})", self.aggregator, self.column)
+//    }
+//}
 
 #[derive(Debug, Clone)]
 pub struct TopSql {

--- a/tesseract-core/src/schema.rs
+++ b/tesseract-core/src/schema.rs
@@ -1,6 +1,7 @@
 use serde_derive::Serialize;
 use std::convert::From;
 
+pub mod aggregator;
 mod json;
 mod xml;
 
@@ -21,6 +22,7 @@ pub use crate::schema::{
     xml::PropertyConfigXML,
 };
 use crate::query_ir::MemberType;
+pub use self::aggregator::Aggregator;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Schema {
@@ -176,7 +178,7 @@ impl From<LevelConfigJson> for Level {
 pub struct Measure{
     pub name: String,
     pub column: String,
-    pub aggregator: String,
+    pub aggregator: Aggregator,
 }
 
 impl From<MeasureConfigJson> for Measure {

--- a/tesseract-core/src/schema/aggregator.rs
+++ b/tesseract-core/src/schema/aggregator.rs
@@ -1,4 +1,3 @@
-use failure::{Error, bail};
 use serde_derive::{Deserialize, Serialize};
 
 // TODO move this to a better place? Does this belong in query_ir?
@@ -10,7 +9,6 @@ use serde_derive::{Deserialize, Serialize};
 // the col is referred to as {},
 // and find and replace is used later to insert the col name
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-#[serde(untagged)]
 pub enum Aggregator {
     #[serde(rename="sum")]
     Sum,
@@ -26,3 +24,12 @@ pub enum Aggregator {
     Custom(String),
 }
 
+//#[cfg(test)]
+//mod test {
+//    use super::*;
+//
+//    #[test]
+//    fn parse_aggregator() {
+//        let 
+//    }
+//}

--- a/tesseract-core/src/schema/aggregator.rs
+++ b/tesseract-core/src/schema/aggregator.rs
@@ -14,12 +14,29 @@ pub enum Aggregator {
     Sum,
     #[serde(rename="avg")]
     Average,
+    // Not yet allowed; needs to be able to roll-up across two times
     #[serde(rename="median")]
     Median,
+    /// Weighted Average is calculated against the measure's value column.
+    /// sum(column * weight_column) / sum(weight_column)
     #[serde(rename="weighted-avg")]
-    WeightedAverage,
+    WeightedAverage {
+        weight_column: String,
+
+    },
+    /// Where the measure column is the primary value,
+    /// and a list of secondary column is provided to the MO aggregator:
+    ///
+    /// The general equation for Margin of Error is
+    /// ```
+    /// 1.645 * pow(0.05 * (pow(sum(column) - sum(secondary_columns[0]), 2) + pow(sum(column) - sum(secondar_columns_[1]), 2) + ...), 0.5)
+    /// ```
     #[serde(rename="moe")]
-    Moe,
+    Moe {
+        secondary_columns: Vec<String>,
+    },
+    // This only works for straightforward aggregations, which will work across
+    // two roll-ups. For example, median won't work across two roll-ups
     #[serde(rename="custom")]
     Custom(String),
 }

--- a/tesseract-core/src/schema/aggregator.rs
+++ b/tesseract-core/src/schema/aggregator.rs
@@ -24,12 +24,29 @@ pub enum Aggregator {
     Custom(String),
 }
 
-//#[cfg(test)]
-//mod test {
-//    use super::*;
-//
-//    #[test]
-//    fn parse_aggregator() {
-//        let 
-//    }
-//}
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json;
+
+    // temp struct for doing serde test
+    #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+    struct Measure {
+        col: String,
+        aggregator: Aggregator,
+    }
+
+    #[test]
+    fn parse_basic() {
+        let sum = r#"{ "col": "testcol", "aggregator": "sum" }"#;
+        let parsed: Measure = serde_json::from_str(sum).unwrap();
+        assert_eq!(parsed.aggregator, Aggregator::Sum);
+    }
+
+    #[test]
+    fn parse_custom() {
+        let sum = r#"{ "col": "testcol", "aggregator": { "custom": "{}*{}" } }"#;
+        let parsed: Measure = serde_json::from_str(sum).unwrap();
+        assert_eq!(parsed.aggregator, Aggregator::Custom("{}*{}".to_owned()));
+    }
+}

--- a/tesseract-core/src/schema/aggregator.rs
+++ b/tesseract-core/src/schema/aggregator.rs
@@ -1,0 +1,28 @@
+use failure::{Error, bail};
+use serde_derive::{Deserialize, Serialize};
+
+// TODO move this to a better place? Does this belong in query_ir?
+// Median is the one that postgres and mysql don't support
+// That means that the actual string generation happens
+// inside each db's sql implementation
+//
+// For custom calculations,
+// the col is referred to as {},
+// and find and replace is used later to insert the col name
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Aggregator {
+    #[serde(rename="sum")]
+    Sum,
+    #[serde(rename="avg")]
+    Average,
+    #[serde(rename="median")]
+    Median,
+    #[serde(rename="weighted-avg")]
+    WeightedAverage,
+    #[serde(rename="moe")]
+    Moe,
+    #[serde(rename="custom")]
+    Custom(String),
+}
+

--- a/tesseract-core/src/schema/aggregator.rs
+++ b/tesseract-core/src/schema/aggregator.rs
@@ -19,7 +19,7 @@ pub enum Aggregator {
     Median,
     /// Weighted Average is calculated against the measure's value column.
     /// sum(column * weight_column) / sum(weight_column)
-    #[serde(rename="weighted-avg")]
+    #[serde(rename="weighted_avg")]
     WeightedAverage {
         weight_column: String,
 

--- a/tesseract-core/src/schema/json.rs
+++ b/tesseract-core/src/schema/json.rs
@@ -1,6 +1,7 @@
 use serde_derive::Deserialize;
 
 use crate::query_ir::MemberType;
+use super::aggregator::Aggregator;
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct SchemaConfigJson {
@@ -58,7 +59,7 @@ pub struct LevelConfigJson {
 pub struct MeasureConfigJson {
     pub name: String,
     pub column: String,
-    pub aggregator: String,
+    pub aggregator: Aggregator,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]

--- a/tesseract-core/src/schema/xml.rs
+++ b/tesseract-core/src/schema/xml.rs
@@ -13,6 +13,7 @@ use serde_derive::Deserialize;
 use serde_derive::Serialize;
 
 use crate::query_ir::MemberType;
+use super::aggregator::Aggregator;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SchemaConfigXML {
@@ -80,7 +81,7 @@ pub struct LevelConfigXML {
 pub struct MeasureConfigXML {
     pub name: String,
     pub column: String,
-    pub aggregator: String,
+    pub aggregator: Aggregator,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -100,6 +101,7 @@ pub struct PropertyConfigXML {
 #[cfg(test)]
 mod test {
     use super::*;
+    use serde_xml_rs as serde_xml;
 
     #[test]
     fn xml_schema_config() {

--- a/tesseract-core/src/sql.rs
+++ b/tesseract-core/src/sql.rs
@@ -95,3 +95,57 @@ pub(crate) fn standard_sql(
     final_sql = format!("{} group by {};", final_sql, drill_cols);
     final_sql
 }
+
+#[cfg(test)]
+mod test {
+    #[test]
+    /// Tests:
+    /// - basic standard sql generation
+    /// - join dim table or inline
+    /// - cuts on multi-level dim
+    /// - parents
+    ///
+    fn test_standard_sql() {
+        //"select valid_projects.id, name, sum(commits) from project_facts inner join valid_projects on project_facts.project_id = valid_projects.id where valid_projects.id=442841 group by name;"
+        let table = TableSql {
+            name: "project_facts".into(),
+            primary_key: Some("id".into()),
+        };
+        let cuts = vec![
+            CutSql {
+                foreign_key: "project_id".into(),
+                primary_key: "id".into(),
+                table: Table { name: "valid_projects".into(), schema: None, primary_key: None },
+                column: "id".into(),
+                members: vec!["3".into()],
+                member_type: MemberType::NonText,
+            },
+        ];
+        let drills = vec![
+            // this dim is inline, so should use the fact table
+            // also has parents, so has 
+            DrilldownSql {
+                alias_postfix: "".into(),
+                foreign_key: "project_id".into(),
+                primary_key: "id".into(),
+                table: Table { name: "valid_projects".into(), schema: None, primary_key: None },
+                level_columns: vec![
+                    LevelColumn {
+                        key_column: "id".into(),
+                        name_column: Some("name".to_owned()),
+                    },
+                ],
+                property_columns: vec![],
+            },
+        ];
+        let meas = vec![
+            MeasureSql { aggregator: Aggregator::Sum, column: "commits".into() }
+        ];
+
+        assert_eq!(
+            standard_sql(&table, &cuts, &drills, &meas, &None, &None, &None, &None, &None),
+            "select valid_projects.id, valid_projects.name, sum(commits) from project_facts inner join valid_projects on valid_projects.id = project_facts.project_id where valid_projects.id in (3) group by valid_projects.id, valid_projects.name;".to_owned()
+        );
+    }
+}
+

--- a/tesseract-core/src/sql.rs
+++ b/tesseract-core/src/sql.rs
@@ -37,8 +37,8 @@ pub(crate) fn standard_sql(
             Aggregator::Average => format!("avg"),
             // median doesn't work like this
             Aggregator::Median => format!("median"),
-            Aggregator::WeightedAverage => format!("avg"),
-            Aggregator::Moe => format!(""),
+            Aggregator::WeightedAverage {..} => format!("avg"),
+            Aggregator::Moe {..} => format!(""),
             Aggregator::Custom(s) => format!("{}", s),
         }
     }

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -64,9 +64,9 @@ fn main() -> Result<(), Error> {
     // NOTE: Local schema is the only supported SchemaSource for now
     let schema_source = SchemaSource::LocalSchema { filepath: schema_path.clone() };
 
-    let schema = schema_config::read_schema(&schema_path).unwrap_or_else(|err| {
-        panic!(err);
-    });
+    let schema = schema_config::read_schema(&schema_path).map_err(|err| {
+        format_err!("Error reading schema: {}", err)
+    })?;
     let schema_arc = Arc::new(RwLock::new(schema));
 
     // Env

--- a/weighted_avg.md
+++ b/weighted_avg.md
@@ -1,0 +1,163 @@
+Example for looking at weighted avg calculation
+
+Setup:
+```
+mochi :) create table test_weighted (id Int32, val Int32, weight Int32) Engine=MergeTree() Order By id;
+mochi :) insert into test_weighted (id, val, weight) values (1,1, 1100), (2,2, 1200), (3,3, 1300), (4,4, 1400), (1, 5, 1500), (2,6, 1600), (3,7, 1700), (4,8, 1800)
+mochi :) create table test_weighted_dim (id Int32, label String, group_id Int32, group_label String) Engine=MergeTree() Order By id;
+mochi :) insert into test_weighted_dim (id, label, group_id, group_label) values (1, 'state1', 1, 'country1'), (2, 'state2', 1, 'country1'), (3, 'state3', 2, 'country2'), (4,'state4', 2, 'country2')
+```
+
+Aggregating on lowest level of dim, no dim table join
+```
+mochi :) select id, sum(val*weight) / sum(weight) from test_weighted group by id
+
+SELECT 
+    id, 
+    sum(val * weight) / sum(weight)
+FROM test_weighted 
+GROUP BY id
+
+┌─id─┬─divide(sum(multiply(val, weight)), sum(weight))─┐
+│  4 │                                            6.25 │
+│  3 │                               5.266666666666667 │
+│  2 │                               4.285714285714286 │
+│  1 │                              3.3076923076923075 │
+└────┴─────────────────────────────────────────────────┘
+
+4 rows in set. Elapsed: 0.007 sec. 
+```
+
+Aggregating on lowest level of dim, with join
+```
+mochi :) select id, label, group_id, group_label, weighted_num / weighted_denom from (select id, label, group_id, group_label from test_weighted_dim) all inner join (select id, sum(val*weight) as weighted_num, sum(weight) as weighted_denom from test_weighted group by id) using id
+
+SELECT 
+    id, 
+    label, 
+    group_id, 
+    group_label, 
+    weighted_num / weighted_denom
+FROM 
+(
+    SELECT 
+        id, 
+        label, 
+        group_id, 
+        group_label
+    FROM test_weighted_dim 
+) 
+ALL INNER JOIN 
+(
+    SELECT 
+        id, 
+        sum(val * weight) AS weighted_num, 
+        sum(weight) AS weighted_denom
+    FROM test_weighted 
+    GROUP BY id
+) USING (id)
+
+┌─id─┬─label──┬─group_id─┬─group_label─┬─divide(weighted_num, weighted_denom)─┐
+│  1 │ state1 │        1 │ country1    │                   3.3076923076923075 │
+│  2 │ state2 │        1 │ country1    │                    4.285714285714286 │
+│  3 │ state3 │        2 │ country2    │                    5.266666666666667 │
+│  4 │ state4 │        2 │ country2    │                                 6.25 │
+└────┴────────┴──────────┴─────────────┴──────────────────────────────────────┘
+
+4 rows in set. Elapsed: 0.005 sec. 
+```
+
+Intermediate group by, for parent level agg (the fast way)
+```
+mochi :) select group_id, group_label, sum(weighted_num)/sum(weighted_denom) from (select id, label, group_id, group_label, weighted_num, weighted_denom from (select id, label, group_id, group_label from test_weighted_dim) all inner join (select id, sum(val*weight) as weighted_num, sum(weight) as weighted_denom from test_weighted group by id) using id) group by group_id, group_label
+
+SELECT 
+    group_id, 
+    group_label, 
+    sum(weighted_num) / sum(weighted_denom)
+FROM 
+(
+    SELECT 
+        id, 
+        label, 
+        group_id, 
+        group_label, 
+        weighted_num, 
+        weighted_denom
+    FROM 
+    (
+        SELECT 
+            id, 
+            label, 
+            group_id, 
+            group_label
+        FROM test_weighted_dim 
+    ) 
+    ALL INNER JOIN 
+    (
+        SELECT 
+            id, 
+            sum(val * weight) AS weighted_num, 
+            sum(weight) AS weighted_denom
+        FROM test_weighted 
+        GROUP BY id
+    ) USING (id)
+) 
+GROUP BY 
+    group_id, 
+    group_label
+
+┌─group_id─┬─group_label─┬─divide(sum(weighted_num), sum(weighted_denom))─┐
+│        2 │ country2    │                              5.774193548387097 │
+│        1 │ country1    │                              3.814814814814815 │
+└──────────┴─────────────┴────────────────────────────────────────────────┘
+
+2 rows in set. Elapsed: 0.006 sec. 
+```
+
+No initial group by, for parent level agg (this is the slow way, since you have to join on granular rows, instead of an aggregate row)
+```
+mochi :) select group_id, group_label, sum(val * weight)/sum(weight) from (select id, label, group_id, group_label, val, weight from (select id, label, group_id, group_label from test_weighted_dim) all inner join (select id,  val, weight from test_weighted) using id) group by group_id, group_label
+
+SELECT 
+    group_id, 
+    group_label, 
+    sum(val * weight) / sum(weight)
+FROM 
+(
+    SELECT 
+        id, 
+        label, 
+        group_id, 
+        group_label, 
+        val, 
+        weight
+    FROM 
+    (
+        SELECT 
+            id, 
+            label, 
+            group_id, 
+            group_label
+        FROM test_weighted_dim 
+    ) 
+    ALL INNER JOIN 
+    (
+        SELECT 
+            id, 
+            val, 
+            weight
+        FROM test_weighted 
+    ) USING (id)
+) 
+GROUP BY 
+    group_id, 
+    group_label
+
+┌─group_id─┬─group_label─┬─divide(sum(multiply(val, weight)), sum(weight))─┐
+│        2 │ country2    │                               5.774193548387097 │
+│        1 │ country1    │                               3.814814814814815 │
+└──────────┴─────────────┴─────────────────────────────────────────────────┘
+
+2 rows in set. Elapsed: 0.007 sec. 
+```


### PR DESCRIPTION
Implements moe and weighted avg

Has some reworking of how aggregations are passed through subqueries. Basically, for moe and weighted avg, only sum(col) can be performed on the fact scan, and then the whole formula can be applied after joining with the dim tables and rolling up on parent levels.

Handling of aggregation sql generation put into own module, and has some tests.