### PR TITLE
Feature/cut exclude sql

### DIFF
--- a/tesseract-clickhouse/src/sql/options.rs
+++ b/tesseract-clickhouse/src/sql/options.rs
@@ -70,9 +70,13 @@ pub fn wrap_options(
         }
     };
 
-    let filters_sql = filters.iter()
-        .map(|f| format!("{} {}", f.by_column, f.constraint.sql_string()));
-    let filters_sql = format!("where {}", join(filters_sql, " and "));
+    let filters_sql = if !filters.is_empty() {
+        let filter_clauses = filters.iter()
+            .map(|f| format!("{} {}", f.by_column, f.constraint.sql_string()));
+        format!("where {}", join(filter_clauses, " and "))
+    } else {
+        "".into()
+    };
 
 
     final_sql = format!("select * from ({}) {} {} {}",

--- a/tesseract-clickhouse/src/sql/primary_agg.rs
+++ b/tesseract-clickhouse/src/sql/primary_agg.rs
@@ -120,16 +120,17 @@ pub fn primary_agg(
     if (inline_cuts.len() > 0) || (ext_cuts_for_inline.len() > 0) {
         let inline_cut_clause = inline_cuts
             .iter()
-            .map(|c| format!("{} in ({})", c.column, c.members_string()));
+            .map(|c| format!("{} {} ({})", c.column, c.mask_sql_string(), c.members_string()));
 
         let ext_cut_clause = ext_cuts_for_inline
             .iter()
             .map(|c| {
-                format!("{} in (select {} from {} where {} in ({}))",
+                format!("{} in (select {} from {} where {} {} ({}))",
                     c.foreign_key,
                     c.primary_key,
                     c.table.full_name(),
                     c.column,
+                    c.mask_sql_string(),
                     c.members_string(),
                     )
             });

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -492,6 +492,7 @@ impl Schema {
                 column,
                 members: cut.members.clone(),
                 member_type: level.key_type.clone().unwrap_or(MemberType::NonText),
+                mask: cut.mask.clone(),
             });
         }
 

--- a/tesseract-core/src/names.rs
+++ b/tesseract-core/src/names.rs
@@ -474,6 +474,7 @@ mod test {
         println!("{}", drilldown);
         println!("{}", cut1);
         println!("{}", cut2);
+        println!("{}", cut2_not);
         println!("{}", property);
 
         panic!();

--- a/tesseract-core/src/query_ir.rs
+++ b/tesseract-core/src/query_ir.rs
@@ -1,6 +1,7 @@
 use itertools::join;
 use serde_derive::{Deserialize, Serialize};
 
+use crate::names::Mask;
 use crate::query::{LimitQuery, SortDirection, Constraint};
 use crate::schema::Table;
 use crate::schema::aggregator::Aggregator;
@@ -174,6 +175,8 @@ pub struct CutSql {
     pub column: String,
     pub members: Vec<String>,
     pub member_type: MemberType,
+    // Mask is Includes or Excludes on set of cut members
+    pub mask: Mask,
 }
 
 impl CutSql {
@@ -191,6 +194,13 @@ impl CutSql {
 
     pub fn col_qual_string(&self) -> String {
         format!("{}.{}", self.table.name, self.column)
+    }
+
+    pub fn mask_sql_string(&self) -> String {
+        match self.mask {
+            Mask::Include => "in".into(),
+            Mask::Exclude => "not in".into(),
+        }
     }
 }
 


### PR DESCRIPTION
wires in cut with new mask feature to:
- mask in CutSql
- using `not in` for sql gen in clickhouse (even though its says for [core])

Also fixes a bug in `filter`, where I was always showing the `where` clause, even if empty.