### PR TITLE
[core][clickhouse] Implement first phase search in cut

### DIFF
--- a/tesseract-clickhouse/src/sql.rs
+++ b/tesseract-clickhouse/src/sql.rs
@@ -1,4 +1,5 @@
 mod aggregator;
+mod cuts;
 mod growth;
 mod options;
 mod primary_agg;

--- a/tesseract-clickhouse/src/sql/cuts.rs
+++ b/tesseract-clickhouse/src/sql/cuts.rs
@@ -1,0 +1,10 @@
+use super::CutSql;
+
+pub fn cut_sql_string(cut: &CutSql) -> String {
+    if cut.for_match {
+        format!("{}", cut.members_like_string())
+    } else {
+        // col not in ('', '',...)
+        format!("{} {} ({})", cut.column, cut.mask_sql_in_string(), cut.members_string())
+    }
+}

--- a/tesseract-clickhouse/src/sql/primary_agg.rs
+++ b/tesseract-clickhouse/src/sql/primary_agg.rs
@@ -5,6 +5,7 @@ use super::aggregator::{
     agg_sql_string_pass_2,
     agg_sql_string_select_mea,
 };
+use super::cuts::cut_sql_string;
 use super::{
     TableSql,
     CutSql,
@@ -120,18 +121,16 @@ pub fn primary_agg(
     if (inline_cuts.len() > 0) || (ext_cuts_for_inline.len() > 0) {
         let inline_cut_clause = inline_cuts
             .iter()
-            .map(|c| format!("{} {} ({})", c.column, c.mask_sql_string(), c.members_string()));
+            .map(|c| cut_sql_string(&c));
 
         let ext_cut_clause = ext_cuts_for_inline
             .iter()
             .map(|c| {
-                format!("{} in (select {} from {} where {} {} ({}))",
+                format!("{} in (select {} from {} where {})",
                     c.foreign_key,
                     c.primary_key,
                     c.table.full_name(),
-                    c.column,
-                    c.mask_sql_string(),
-                    c.members_string(),
+                    cut_sql_string(&c),
                     )
             });
 

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -483,16 +483,27 @@ impl Schema {
                 .clone()
                 .ok_or(format_err!("No foreign key; it's required for now (until inline dim implemented)"))?;
 
-            let column = level.key_column.clone();
+            let column = if cut.for_match {
+                level.name_column.clone().unwrap_or(level.key_column.clone())
+            } else {
+                level.key_column.clone()
+            };
+
+            let member_type = if cut.for_match {
+                MemberType::Text
+            } else {
+                level.key_type.clone().unwrap_or(MemberType::NonText)
+            };
 
             res.push(CutSql {
                 table,
                 primary_key,
                 foreign_key,
                 column,
+                member_type,
                 members: cut.members.clone(),
-                member_type: level.key_type.clone().unwrap_or(MemberType::NonText),
                 mask: cut.mask.clone(),
+                for_match: cut.for_match,
             });
         }
 

--- a/tesseract-core/src/query_ir.rs
+++ b/tesseract-core/src/query_ir.rs
@@ -177,6 +177,8 @@ pub struct CutSql {
     pub member_type: MemberType,
     // Mask is Includes or Excludes on set of cut members
     pub mask: Mask,
+    // if for_match, then use LIKE syntax
+    pub for_match: bool,
 }
 
 impl CutSql {
@@ -192,14 +194,46 @@ impl CutSql {
         format!("{}", members)
     }
 
+    pub fn members_like_string(&self) -> String {
+        match self.member_type {
+            MemberType::NonText => {
+                // this behavior doesn't really make sense; it should be for
+                // labels only, which are almost always strings.
+                let unquoted = self.members.iter()
+                    .map(|m| format!("{} {} {}", self.column, self.mask_sql_like_string(), m));
+
+                match self.mask {
+                    Mask::Include => format!("{}", join(unquoted, " or ")),
+                    Mask::Exclude => format!("{}", join(unquoted, " and ")),
+                }
+            },
+            MemberType::Text => {
+                let quoted = self.members.iter()
+                    .map(|m| format!("{} {} '%{}%'", self.column, self.mask_sql_like_string(), m));
+
+                match self.mask {
+                    Mask::Include => format!("{}", join(quoted, " or ")),
+                    Mask::Exclude => format!("{}", join(quoted, " and ")),
+                }
+            }
+        }
+    }
+
     pub fn col_qual_string(&self) -> String {
         format!("{}.{}", self.table.name, self.column)
     }
 
-    pub fn mask_sql_string(&self) -> String {
+    pub fn mask_sql_in_string(&self) -> String {
         match self.mask {
             Mask::Include => "in".into(),
             Mask::Exclude => "not in".into(),
+        }
+    }
+
+    pub fn mask_sql_like_string(&self) -> String {
+        match self.mask {
+            Mask::Include => "like".into(),
+            Mask::Exclude => "not like".into(),
         }
     }
 }


### PR DESCRIPTION
The first phase of searching in cuts is a little limited:

- the switch applies to all members in a dimension:
  cuts[]=*Geography.State.State.Cali,Ark
- matching happens using '%xxxxx%'
- when using this search match, it always happens on labels if
  available, fallback to key if not.

So, you can't specify per member whether it's:
- NOT
- prefix/postfix/any matching
- on key or label