### PR TITLE
[logic layer] Name sets support

### DIFF
--- a/tesseract-server/src/logic_layer/cache.rs
+++ b/tesseract-server/src/logic_layer/cache.rs
@@ -234,44 +234,63 @@ pub fn get_time_values(
     };
 
     if df.columns.len() >= 1 {
-        let mut values: Vec<String> = match &df.columns[0].column_data {
+        let values: Vec<String> = match &df.columns[0].column_data {
             ColumnData::Int8(v) => {
-                v.iter().map(|&e| e.to_string()).collect()
+                let mut t: Vec<u32> = v.iter().map(|&e| e.clone() as u32).collect();
+                t.sort();
+                t.iter().map(|&e| e.to_string()).collect()
             },
             ColumnData::Int16(v) => {
-                v.iter().map(|&e| e.to_string()).collect()
+                let mut t: Vec<u32> = v.iter().map(|&e| e.clone() as u32).collect();
+                t.sort();
+                t.iter().map(|&e| e.to_string()).collect()
             },
             ColumnData::Int32(v) => {
-                v.iter().map(|&e| e.to_string()).collect()
+                let mut t: Vec<u32> = v.iter().map(|&e| e.clone() as u32).collect();
+                t.sort();
+                t.iter().map(|&e| e.to_string()).collect()
             },
             ColumnData::Int64(v) => {
-                v.iter().map(|&e| e.to_string()).collect()
+                let mut t: Vec<u32> = v.iter().map(|&e| e.clone() as u32).collect();
+                t.sort();
+                t.iter().map(|&e| e.to_string()).collect()
             },
             ColumnData::UInt8(v) => {
-                v.iter().map(|&e| e.to_string()).collect()
+                let mut t: Vec<u32> = v.iter().map(|&e| e.clone() as u32).collect();
+                t.sort();
+                t.iter().map(|&e| e.to_string()).collect()
             },
             ColumnData::UInt16(v) => {
-                v.iter().map(|&e| e.to_string()).collect()
+                let mut t: Vec<u32> = v.iter().map(|&e| e.clone() as u32).collect();
+                t.sort();
+                t.iter().map(|&e| e.to_string()).collect()
             },
             ColumnData::UInt32(v) => {
-                v.iter().map(|&e| e.to_string()).collect()
+                let mut t: Vec<u32> = v.iter().map(|&e| e.clone() as u32).collect();
+                t.sort();
+                t.iter().map(|&e| e.to_string()).collect()
             },
             ColumnData::UInt64(v) => {
-                v.iter().map(|&e| e.to_string()).collect()
+                let mut t: Vec<u32> = v.iter().map(|&e| e.clone() as u32).collect();
+                t.sort();
+                t.iter().map(|&e| e.to_string()).collect()
             },
             ColumnData::Float32(v) => {
-                v.iter().map(|&e| e.to_string()).collect()
+                let mut t: Vec<u32> = v.iter().map(|&e| e.clone() as u32).collect();
+                t.sort();
+                t.iter().map(|&e| e.to_string()).collect()
             },
             ColumnData::Float64(v) => {
-                v.iter().map(|&e| e.to_string()).collect()
+                let mut t: Vec<u32> = v.iter().map(|&e| e.clone() as u32).collect();
+                t.sort();
+                t.iter().map(|&e| e.to_string()).collect()
             },
             ColumnData::Text(v) => {
-                v.to_vec()
+                let mut t = v.to_vec();
+                t.sort();
+                t
             },
         };
-
-        // TODO: Fix this ordering (months)
-        values.sort();
 
         return Ok(values);
     }

--- a/tesseract-server/src/logic_layer/config.rs
+++ b/tesseract-server/src/logic_layer/config.rs
@@ -7,6 +7,7 @@ use serde_json;
 #[derive(Debug, Clone, Deserialize)]
 pub struct LogicLayerConfig {
     pub aliases: Option<AliasConfig>,
+    pub name_sets: Option<Vec<NameSetsConfig>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -18,6 +19,18 @@ pub struct AliasConfig {
 pub struct CubeAliasConfig {
     pub name: String,
     pub alternatives: Vec<String>
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct NameSetsConfig {
+    pub level_name: String,
+    pub sets: Vec<NameSetConfig>
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct NameSetConfig {
+    pub set_name: String,
+    pub values: Vec<String>
 }
 
 

--- a/tesseract-server/src/logic_layer/config.rs
+++ b/tesseract-server/src/logic_layer/config.rs
@@ -70,4 +70,40 @@ impl LogicLayerConfig {
             None => return Ok(name)
         };
     }
+
+    /// Given a cut string, find if that matches any of the substitutions
+    /// defined in `name_sets`. If so, substitute the cut value.
+    pub fn substitute_cut(self, level_name: String, cut: String) -> String {
+        match self.name_sets {
+            Some(name_sets) => {
+                let cuts: Vec<String> = cut.split(",").map(|s| s.to_string()).collect();
+
+                let mut final_cuts: Vec<String> = vec![];
+
+                for c in cuts.clone() {
+                    let mut found = false;
+
+                    for name_set in name_sets.clone() {
+                        if name_set.level_name == level_name {
+                            for set in name_set.sets.clone() {
+                                if c == set.set_name {
+                                    final_cuts.extend(set.values);
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    // No substitutions found, so just add the raw cut
+                    if found == false {
+                        final_cuts.push(c);
+                    }
+                }
+
+                final_cuts.join(",")
+            },
+            None => cut
+        }
+    }
 }

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -91,7 +91,6 @@ fn main() -> Result<(), Error> {
                 Ok(config_obj) => config_obj,
                 Err(err) => return Err(err)
             };
-
             Some(Arc::new(RwLock::new(logic_layer_config)))
         },
         Err(_) => None

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -91,6 +91,7 @@ fn main() -> Result<(), Error> {
                 Ok(config_obj) => config_obj,
                 Err(err) => return Err(err)
             };
+
             Some(Arc::new(RwLock::new(logic_layer_config)))
         },
         Err(_) => None


### PR DESCRIPTION
Proposed config syntax:

```json
{
    "aliases": {
        "cubes": [
            {
                "name": "Sales",
                "alternatives": ["sales", "sale"]
            }
        ]
    },
    "name_sets": [
        {
            "level_name": "Category",
            "sets": [
                {
                    "set_name": "Set 1",
                    "values": ["Books", "Videos"]
                },
                {
                    "set_name": "Set 2",
                    "values": ["Sports", "Various"]
                }
            ]
        }
    ]
}
```