### PR TITLE
allow non-unique level names

### DIFF
--- a/tesseract-server/src/handlers/aggregate_stream.rs
+++ b/tesseract-server/src/handlers/aggregate_stream.rs
@@ -1,24 +1,19 @@
 use actix_web::{
-    AsyncResponder,
     FutureResponse,
     HttpRequest,
     HttpResponse,
     Path,
 };
-use failure::Error;
-use futures::future::{self, Future};
-use futures::Stream;
+use futures::future;
 use lazy_static::lazy_static;
 use log::*;
-use serde_derive::{Serialize, Deserialize};
 use serde_qs as qs;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 use tesseract_core::format::FormatType;
 use tesseract_core::format_stream::format_records_stream;
 use tesseract_core::Query as TsQuery;
 
 use crate::app::AppState;
-use crate::errors::ServerError;
 use super::aggregate::AggregateQueryOpt;
 
 /// Handles default aggregation when a format is not specified.

--- a/tesseract-server/src/handlers/logic_layer/mod.rs
+++ b/tesseract-server/src/handlers/logic_layer/mod.rs
@@ -4,3 +4,20 @@ pub mod shared;
 pub use self::aggregate::logic_layer_handler;
 pub use self::aggregate::logic_layer_default_handler;
 pub use self::shared::{Time, TimePrecision, TimeValue, LogicLayerQueryOpt, boxed_error};
+
+use actix_web::{HttpRequest, HttpResponse, Path};
+use crate::app::AppState;
+
+pub fn logic_layer_non_unique_levels_default_handler(
+    (_req, _cube): (HttpRequest<AppState>, Path<()>),
+    ) -> HttpResponse
+{
+    HttpResponse::InternalServerError().body("Error Code 555")
+}
+
+pub fn logic_layer_non_unique_levels_handler(
+    (_req, _cube): (HttpRequest<AppState>, Path<(String)>),
+    ) -> HttpResponse
+{
+    HttpResponse::InternalServerError().body("Error Code 555")
+}

--- a/tesseract-server/src/handlers/mod.rs
+++ b/tesseract-server/src/handlers/mod.rs
@@ -11,6 +11,8 @@ pub use self::aggregate_stream::aggregate_handler as aggregate_stream_handler;
 pub use self::aggregate_stream::aggregate_default_handler as aggregate_stream_default_handler;
 pub use self::logic_layer::logic_layer_handler;
 pub use self::logic_layer::logic_layer_default_handler;
+pub use self::logic_layer::logic_layer_non_unique_levels_handler;
+pub use self::logic_layer::logic_layer_non_unique_levels_default_handler;
 pub use self::flush::flush_handler;
 pub use self::index::index_handler;
 pub use self::metadata::members_handler;

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -106,6 +106,7 @@ fn main() -> Result<(), Error> {
     let schema_source = SchemaSource::LocalSchema { filepath: schema_path.clone() };
 
     let schema = schema_config::read_schema(&schema_path)?;
+    let has_unique_levels_properties = schema.has_unique_levels_properties();
     let schema_arc = Arc::new(RwLock::new(schema.clone()));
 
     // Env
@@ -148,6 +149,7 @@ fn main() -> Result<(), Error> {
                 cache_arc.clone(),
                 logic_layer_config.clone(),
                 streaming_response,
+                has_unique_levels_properties,
             )
         )
         .bind(&server_addr)

--- a/tesseract-server/src/schema_config.rs
+++ b/tesseract-server/src/schema_config.rs
@@ -1,5 +1,4 @@
 use failure::{Error, format_err};
-use std::collections::HashSet;
 
 use tesseract_core::Schema;
 
@@ -19,35 +18,15 @@ pub fn read_schema(schema_path: &String) -> Result<Schema, Error> {
         return Err(format_err!("Schema format not supported"))
     }
 
-    for cube in schema.cubes.clone() {
-        let mut levels = HashSet::new();
-        let mut properties = HashSet::new();
-
-        for dimension in cube.dimensions.clone() {
-            for hierarchy in dimension.hierarchies.clone() {
+    // TODO Should this check be done in core?
+    for cube in &schema.cubes {
+        for dimension in &cube.dimensions {
+            for hierarchy in &dimension.hierarchies {
                 let has_table = hierarchy.table.is_some();
                 let has_inline_table = hierarchy.inline_table.is_some();
 
                 if has_table && has_inline_table {
                     return Err(format_err!("Can't have table and inline table definitions in the same hierarchy"))
-                }
-
-                // Check each cube for unique level and property names
-                for level in hierarchy.levels.clone() {
-                    if !levels.insert(level.name) {
-                        return Err(format_err!("Make sure the {} cube has unique level names", cube.name))
-                    }
-
-                    match level.properties {
-                        Some(props) => {
-                            for property in props {
-                                if !properties.insert(property.name) {
-                                    return Err(format_err!("Make sure the {} cube has unique property names", cube.name))
-                                }
-                            }
-                        },
-                        None => continue
-                    }
                 }
             }
         }


### PR DESCRIPTION
Previously, for the sake of the logic layer, we had allowed only unique
level names in the schema.

Now, because we want to be able to have non-unique levels in the raw
schema, we just do a runtime check which changes what routes are loaded.

If unique levels, then regular logic layer is loaded.
If not unique levels, then a route which always returns 500 is loaded
for logic layer.

In the future, the LL will have aliases in the config to allow a
combination of LL and raw schema to have unique levels.