### PR TITLE
[logic layer] Adds name substitutions to logic layer config

### DIFF
--- a/tesseract-core/src/query.rs
+++ b/tesseract-core/src/query.rs
@@ -61,6 +61,20 @@ pub struct TopQuery {
     pub sort_direction: SortDirection,
 }
 
+impl TopQuery  {
+    pub fn new(
+        n: u64, by_dimension: LevelName, sort_mea_or_calc: Vec<MeaOrCalc>,
+        sort_direction: SortDirection
+    ) -> Self {
+        TopQuery {
+            n,
+            by_dimension,
+            sort_mea_or_calc,
+            sort_direction
+        }
+    }
+}
+
 // Currently only allows one sort_measure
 impl FromStr for TopQuery {
     type Err = Error;

--- a/tesseract-core/src/schema.rs
+++ b/tesseract-core/src/schema.rs
@@ -221,6 +221,24 @@ impl Cube {
 
         Err(format_err!("'{}' not found", property_name))
     }
+
+    /// Returns a Level object corresponding to a provided LevelName.
+    pub fn get_level(&self, level_name: &LevelName) -> Option<Level> {
+        for dimension in &self.dimensions {
+            if dimension.name == level_name.dimension {
+                for hierarchy in &dimension.hierarchies {
+                    if hierarchy.name == level_name.hierarchy {
+                        for level in &hierarchy.levels {
+                            if level.name == level_name.level {
+                                return Some(level.clone())
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
 }
 
 

--- a/tesseract-core/src/schema.rs
+++ b/tesseract-core/src/schema.rs
@@ -101,6 +101,7 @@ impl From<SchemaConfigJson> for Schema {
                                     foreign_key: Some(dim_usage.foreign_key.clone()),
                                     hierarchies,
                                     annotations: dim_annotations,
+                                    is_shared: true
                                 });
                             }
                         }
@@ -229,6 +230,7 @@ pub struct Dimension {
     pub foreign_key: Option<String>,
     pub hierarchies: Vec<Hierarchy>,
     pub annotations: Option<Vec<Annotation>>,
+    pub is_shared: bool
 }
 
 impl From<DimensionConfigJson> for Dimension {
@@ -248,6 +250,7 @@ impl From<DimensionConfigJson> for Dimension {
             foreign_key: dimension_config.foreign_key,
             hierarchies,
             annotations,
+            is_shared: false
         }
     }
 }

--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -89,7 +89,12 @@ pub fn logic_layer_aggregation(
                 Err(err) => return boxed_error(err.to_string())
             };
 
-            // TODO: Check for level and property aliases
+//            // TODO: Check for level and property aliases
+//            if let Some(drills) = q.drilldowns {
+//                for drill in drills {
+//
+//                }
+//            }
 
             // Hack for now since can't provide extra arguments on try_into
             q.cube_obj = Some(cube.clone());

--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -89,16 +89,10 @@ pub fn logic_layer_aggregation(
                 Err(err) => return boxed_error(err.to_string())
             };
 
-//            // TODO: Check for level and property aliases
-//            if let Some(drills) = q.drilldowns {
-//                for drill in drills {
-//
-//                }
-//            }
-
             // Hack for now since can't provide extra arguments on try_into
             q.cube_obj = Some(cube.clone());
             q.config = logic_layer_config;
+            q.schema = Some(schema.clone());
             q
         },
         Err(err) => return boxed_error(err.to_string())

--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -72,6 +72,8 @@ pub fn logic_layer_aggregation(
 
     let mut agg_query = match QS_NON_STRICT.deserialize_str::<LogicLayerQueryOpt>(query) {
         Ok(mut q) => {
+            // Check to see if the logic layer config has a alias with the
+            // provided cube name
             cube_name = match logic_layer_config.clone() {
                 Some(llc) => {
                     match llc.sub_cube_name(q.cube.clone()) {
@@ -86,6 +88,8 @@ pub fn logic_layer_aggregation(
                 Ok(c) => c.clone(),
                 Err(err) => return boxed_error(err.to_string())
             };
+
+            // TODO: Check for level and property aliases
 
             // Hack for now since can't provide extra arguments on try_into
             q.cube_obj = Some(cube.clone());

--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -89,8 +89,15 @@ pub fn logic_layer_aggregation(
                 Err(err) => return boxed_error(err.to_string())
             };
 
+            let cube_cache = req.state().cache.read().unwrap().find_cube_info(&cube_name).clone();
+
+            println!(" ");
+            println!("{:?}", cube_cache);
+            println!(" ");
+
             // Hack for now since can't provide extra arguments on try_into
             q.cube_obj = Some(cube.clone());
+            q.cube_cache = cube_cache;
             q.config = logic_layer_config;
             q.schema = Some(schema.clone());
             q

--- a/tesseract-server/src/handlers/logic_layer/shared.rs
+++ b/tesseract-server/src/handlers/logic_layer/shared.rs
@@ -200,10 +200,10 @@ impl LogicLayerQueryOpt {
 
                             match unique_level_name_opt {
                                 Some(unique_level_name) => unique_level_name,
-                                None => &level.name
+                                None => level.name.clone()
                             }
                         },
-                        None => &level.name
+                        None => level.name.clone()
                     };
 
                     level_name_map.insert(
@@ -246,10 +246,10 @@ impl LogicLayerQueryOpt {
 
                                     match unique_property_name_opt {
                                         Some(unique_property_name) => unique_property_name,
-                                        None => &prop.name
+                                        None => prop.name.clone()
                                     }
                                 },
-                                None => &prop.name
+                                None => prop.name.clone()
                             };
 
                             property_map.insert(

--- a/tesseract-server/src/handlers/logic_layer/shared.rs
+++ b/tesseract-server/src/handlers/logic_layer/shared.rs
@@ -454,45 +454,14 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
             .map(|ps| {
                 let mut properties: Vec<Property> = vec![];
 
-                for property_name in LogicLayerQueryOpt::deserialize_args(ps) {
-                    // Check if there is an alias defined with this name
-                    let prop = match &ll_config {
-                        Some(ll_conf) => {
-                            ll_conf.deconstruct_property_alias(
-                                &cube.name,
-                                &property_name,
-                                &schema
-                            )
-                        },
-                        None => None
+                for property_value in LogicLayerQueryOpt::deserialize_args(ps) {
+                    // TODO: Break or bail?
+                    let property = match property_map.get(&property_value) {
+                        Some(p) => p,
+                        None => break
                     };
 
-                    let property = match prop {
-                        Some(p) => {
-                            let prop_split: Vec<String> = p.split(".").map(|s| s.to_string()).collect();
-                            Property::new(
-                                prop_split[0].clone(),
-                                prop_split[1].clone(),
-                                prop_split[2].clone(),
-                                prop_split[3].clone()
-                            )
-                        },
-                        None => {
-                            let (dimension, hierarchy, level) = match cube.identify_property(property_name.clone()) {
-                                Ok(dhl) => dhl,
-                                Err(_) => break
-                            };
-
-                            Property::new(
-                                dimension.clone(),
-                                hierarchy.clone(),
-                                level.clone(),
-                                property_name.clone()
-                            )
-                        }
-                    };
-
-                    properties.push(property);
+                    properties.push(property.clone());
                 }
 
                 properties

--- a/tesseract-server/src/handlers/logic_layer/shared.rs
+++ b/tesseract-server/src/handlers/logic_layer/shared.rs
@@ -498,15 +498,20 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
                     return Err(format_err!("Bad formatting for growth param."));
                 }
 
-                let level = gro_split[0].clone();
+                let level_key = gro_split[0].clone();
                 let measure = gro_split[1].clone();
 
-                let (dimension, hierarchy, _) = match cube.identify_level(level.clone()) {
-                    Ok(dh) => dh,
-                    Err(_) => return Err(format_err!("Unable to identify growth level."))
+                let level_name = match level_map.get(&level_key) {
+                    Some(l) => l,
+                    None => bail!("Unable to find growth level")
                 };
 
-                let growth = GrowthQuery::new(dimension, hierarchy, level, measure);
+                let growth = GrowthQuery::new(
+                    level_name.dimension.clone(),
+                    level_name.hierarchy.clone(),
+                    level_name.level.clone(),
+                    measure
+                );
 
                 Some(growth)
             },
@@ -521,23 +526,27 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
                     return Err(format_err!("Bad formatting for RCA param."));
                 }
 
-                let drill1_l = rca_split[0].clone();
-                let drill2_l = rca_split[1].clone();
+                let drill1_level_key = rca_split[0].clone();
+                let drill2_level_key = rca_split[1].clone();
                 let measure = rca_split[2].clone();
 
-                let (drill1_d, drill1_h, _) = match cube.identify_level(drill1_l.clone()) {
-                    Ok(dh) => dh,
-                    Err(_) => return Err(format_err!("Unable to identify RCA drilldown #1 level."))
+                let level_name_1 = match level_map.get(&drill1_level_key) {
+                    Some(l) => l,
+                    None => bail!("Unable to find drill 1 level")
                 };
 
-                let (drill2_d, drill2_h, _) = match cube.identify_level(drill2_l.clone()) {
-                    Ok(dh) => dh,
-                    Err(_) => return Err(format_err!("Unable to identify RCA drilldown #2 level."))
+                let level_name_2 = match level_map.get(&drill2_level_key) {
+                    Some(l) => l,
+                    None => bail!("Unable to find drill 2 level")
                 };
 
                 let rca = RcaQuery::new(
-                    drill1_d, drill1_h, drill1_l,
-                    drill2_d, drill2_h, drill2_l,
+                    level_name_1.dimension.clone(),
+                    level_name_1.hierarchy.clone(),
+                    level_name_1.level.clone(),
+                    level_name_2.dimension.clone(),
+                    level_name_2.hierarchy.clone(),
+                    level_name_2.level.clone(),
                     measure
                 );
 

--- a/tesseract-server/src/logic_layer/config.rs
+++ b/tesseract-server/src/logic_layer/config.rs
@@ -5,7 +5,6 @@ use serde_derive::Deserialize;
 use serde_json;
 use tesseract_core::Schema;
 use tesseract_core::names::{LevelName, Property};
-use futures::future::Err;
 
 
 #[derive(Debug, Clone, Deserialize)]
@@ -333,9 +332,6 @@ impl LogicLayerConfig {
             let mut properties = HashSet::new();
 
             for dimension in &cube.dimensions {
-//                println!("{:?}", dimension.name);
-//                println!("{:?}", dimension.is_shared);
-
                 for hierarchy in &dimension.hierarchies {
 
                     // Check each cube for unique level and property names

--- a/tesseract-server/src/logic_layer/config.rs
+++ b/tesseract-server/src/logic_layer/config.rs
@@ -12,12 +12,13 @@ use futures::future::Err;
 pub struct LogicLayerConfig {
     pub aliases: Option<AliasConfig>,
     pub named_sets: Option<Vec<NamedSetsConfig>>,
-    pub name_substitutions: Option<NameSubstitutionsConfig>
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct AliasConfig {
     pub cubes: Option<Vec<CubeAliasConfig>>,
+    pub levels: Option<Vec<LevelPropertyConfig>>,
+    pub properties: Option<Vec<LevelPropertyConfig>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -38,21 +39,10 @@ pub struct NamedSetConfig {
     pub values: Vec<String>
 }
 
+// TODO: Might want to consider eventually sharing the same structure as the current CubeAliasConfig
 #[derive(Debug, Clone, Deserialize)]
-pub struct NameSubstitutionsConfig {
-    levels: Option<Vec<NameSubstitutionsLevelConfig>>,
-    properties: Option<Vec<NameSubstitutionsPropertyConfig>>
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct NameSubstitutionsLevelConfig {
-    level: String,
-    unique_name: String
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct NameSubstitutionsPropertyConfig {
-    property: String,
+pub struct LevelPropertyConfig {
+    current_name: String,
     unique_name: String
 }
 
@@ -163,10 +153,10 @@ impl LogicLayerConfig {
 
     /// Returns a unique name definition for a given level if there is one.
     pub fn find_unique_level_name(&self, level_name: &LevelName) -> Result<Option<&str>, Error> {
-        if let Some(name_substitutions) = &self.name_substitutions {
-            if let Some(levels) = &name_substitutions.levels {
+        if let Some(aliases) = &self.aliases {
+            if let Some(levels) = &aliases.levels {
                 for level in levels {
-                    let ll_level_name: LevelName = level.level.parse()?;
+                    let ll_level_name: LevelName = level.current_name.parse()?;
 
                     if &ll_level_name == level_name {
                         return Ok(Some(&level.unique_name))
@@ -179,10 +169,10 @@ impl LogicLayerConfig {
 
     /// Returns a unique name definition for a given property if there is one.
     pub fn find_unique_property_name(&self, property_name: &Property) -> Result<Option<&str>, Error> {
-        if let Some(name_substitutions) = &self.name_substitutions {
-            if let Some(properties) = &name_substitutions.properties {
+        if let Some(aliases) = &self.aliases {
+            if let Some(properties) = &aliases.properties {
                 for property in properties {
-                    let ll_property_name: Property = property.property.parse()?;
+                    let ll_property_name: Property = property.current_name.parse()?;
 
                     if &ll_property_name == property_name {
                         return Ok(Some(&property.unique_name))

--- a/tesseract-server/src/logic_layer/config.rs
+++ b/tesseract-server/src/logic_layer/config.rs
@@ -145,60 +145,6 @@ impl FindUnique for SharedDimensionAliasConfig {
 }
 
 
-trait DeconstructAlias {
-    fn find_level_name(&self, level_name: &str) -> Option<&str>;
-    fn find_property_name(&self, level_name: &str) -> Option<&str>;
-}
-
-impl DeconstructAlias for CubeAliasConfig {
-    fn find_level_name(&self, level_name: &str) -> Option<&str> {
-        if let Some(levels) = &self.levels {
-            for level in levels {
-                if &level.unique_name == level_name {
-                    return Some(&level.current_name)
-                }
-            }
-        }
-        None
-    }
-
-    fn find_property_name(&self, property_name: &str) -> Option<&str> {
-        if let Some(properties) = &self.properties {
-            for property in properties {
-                if &property.unique_name == property_name {
-                    return Some(&property.current_name)
-                }
-            }
-        }
-        None
-    }
-}
-
-impl DeconstructAlias for SharedDimensionAliasConfig {
-    fn find_level_name(&self, level_name: &str) -> Option<&str> {
-        if let Some(levels) = &self.levels {
-            for level in levels {
-                if &level.unique_name == level_name {
-                    return Some(&level.current_name)
-                }
-            }
-        }
-        None
-    }
-
-    fn find_property_name(&self, property_name: &str) -> Option<&str> {
-        if let Some(properties) = &self.properties {
-            for property in properties {
-                if &property.unique_name == property_name {
-                    return Some(&property.current_name)
-                }
-            }
-        }
-        None
-    }
-}
-
-
 /// Reads Logic Layer Config JSON file.
 pub fn read_config(config_path: &String) -> Result<LogicLayerConfig, Error> {
     let config_str = std::fs::read_to_string(&config_path)
@@ -454,67 +400,5 @@ impl LogicLayerConfig {
         }
 
         Ok(true)
-    }
-
-    pub fn find_cube_property_name(&self, cube_name: &String, property_name: &str) -> Option<&str> {
-        if let Some(aliases) = &self.aliases {
-            if let Some(cubes) = &aliases.cubes {
-                for cube in cubes {
-                    if &cube.name == cube_name {
-                        let res = cube.find_level_name(&property_name);
-                        if let Some(res) = res {
-                            return Some(res)
-                        }
-                    }
-                }
-            }
-        }
-        None
-    }
-
-    pub fn find_shared_dimension_property_name(
-        &self, shared_dimension_name: &String, property_name: &str
-    ) -> Option<&str> {
-        if let Some(aliases) = &self.aliases {
-            if let Some(shared_dimensions) = &aliases.shared_dimensions {
-                for shared_dimension in shared_dimensions {
-                    if &shared_dimension.name == shared_dimension_name {
-                        let res = shared_dimension.find_level_name(&property_name);
-                        if let Some(res) = res {
-                            return Some(res)
-                        }
-                    }
-                }
-            }
-        }
-        None
-    }
-
-    pub fn deconstruct_property_alias(
-        &self, cube_name: &str, property_name: &str, schema: &Schema
-    ) -> Option<&str> {
-        for cube in &schema.cubes {
-            if &cube.name == cube_name {
-                for dimension in &cube.dimensions {
-
-                    let property_name_opt = if dimension.is_shared {
-                        self.find_shared_dimension_property_name(
-                            &dimension.name, &property_name
-                        )
-                    } else {
-                        self.find_cube_property_name(
-                            &cube.name, &property_name
-                        )
-                    };
-
-                    if let Some(property_name) = property_name_opt {
-                        return Some(property_name)
-                    }
-
-                }
-            }
-        }
-
-        None
     }
 }

--- a/tesseract-server/src/logic_layer/config.rs
+++ b/tesseract-server/src/logic_layer/config.rs
@@ -162,44 +162,40 @@ impl LogicLayerConfig {
     }
 
     /// Returns a unique name definition for a given level if there is one.
-    pub fn find_unique_level_name(&self, level_name: &LevelName) -> Option<&str> {
+    pub fn find_unique_level_name(&self, level_name: &LevelName) -> Result<Option<&str>, Error> {
         if let Some(name_substitutions) = &self.name_substitutions {
             if let Some(levels) = &name_substitutions.levels {
                 for level in levels {
-                    let ll_level_name: Result<LevelName, Error> = level.level.parse();
+                    let ll_level_name: LevelName = level.level.parse()?;
 
-                    if let Ok(ll_level_name) = ll_level_name {
-                        if &ll_level_name == level_name {
-                            return Some(&level.unique_name)
-                        }
+                    if &ll_level_name == level_name {
+                        return Ok(Some(&level.unique_name))
                     }
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     /// Returns a unique name definition for a given property if there is one.
-    pub fn find_unique_property_name(&self, property_name: &Property) -> Option<&str> {
+    pub fn find_unique_property_name(&self, property_name: &Property) -> Result<Option<&str>, Error> {
         if let Some(name_substitutions) = &self.name_substitutions {
             if let Some(properties) = &name_substitutions.properties {
                 for property in properties {
-                    let ll_property_name: Result<Property, Error> = property.property.parse();
+                    let ll_property_name: Property = property.property.parse()?;
 
-                    if let Ok(ll_property_name) = ll_property_name {
-                        if &ll_property_name == property_name {
-                            return Some(&property.unique_name)
-                        }
+                    if &ll_property_name == property_name {
+                        return Ok(Some(&property.unique_name))
                     }
                 }
             }
         }
-        None
+        Ok(None)
     }
 
     /// Ensures level and property names are unique inside each cube based on
     /// name substitutions from a logic layer configuration.
-    pub fn has_unique_levels_properties(&self, schema: &Schema) -> bool {
+    pub fn has_unique_levels_properties(&self, schema: &Schema) -> Result<bool, Error> {
         for cube in &schema.cubes {
             let mut levels = HashSet::new();
             let mut properties = HashSet::new();
@@ -215,13 +211,13 @@ impl LogicLayerConfig {
                             level.name.clone()
                         );
 
-                        let unique_level_name = match self.find_unique_level_name(&level_name) {
+                        let unique_level_name = match self.find_unique_level_name(&level_name)? {
                             Some(unique_level_name) => unique_level_name,
                             None => &level.name
                         };
 
                         if !levels.insert(unique_level_name) {
-                            return false
+                            return Ok(false)
                         }
 
                         if let Some(ref props) = level.properties {
@@ -233,13 +229,13 @@ impl LogicLayerConfig {
                                     property.name.clone()
                                 );
 
-                                let unique_property_name = match self.find_unique_property_name(&property_name) {
+                                let unique_property_name = match self.find_unique_property_name(&property_name)? {
                                     Some(unique_property_name) => unique_property_name,
                                     None => &property.name
                                 };
 
                                 if !properties.insert(unique_property_name) {
-                                    return false
+                                    return Ok(false)
                                 }
                             }
                         }
@@ -248,6 +244,6 @@ impl LogicLayerConfig {
             }
         }
 
-        true
+        Ok(true)
     }
 }

--- a/tesseract-server/src/logic_layer/mod.rs
+++ b/tesseract-server/src/logic_layer/mod.rs
@@ -1,5 +1,5 @@
 mod cache;
 mod config;
 
-pub use self::cache::{Cache, populate_cache};
+pub use self::cache::{Cache, CubeCache, populate_cache};
 pub use self::config::{LogicLayerConfig, read_config};

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> Result<(), Error> {
     let schema_source = SchemaSource::LocalSchema { filepath: schema_path.clone() };
 
     let schema = schema_config::read_schema(&schema_path)?;
-    let has_unique_levels_properties = schema.has_unique_levels_properties();
+    let mut has_unique_levels_properties = schema.has_unique_levels_properties();
     let schema_arc = Arc::new(RwLock::new(schema.clone()));
 
     // Env
@@ -130,7 +130,10 @@ fn main() -> Result<(), Error> {
     let logic_layer_config = match env::var("TESSERACT_LOGIC_LAYER_CONFIG_FILEPATH") {
         Ok(config_path) => {
             let logic_layer_config = match logic_layer::read_config(&config_path) {
-                Ok(config_obj) => config_obj,
+                Ok(config_obj) => {
+                    has_unique_levels_properties = config_obj.has_unique_levels_properties(&schema);
+                    config_obj
+                },
                 Err(err) => return Err(err)
             };
             Some(Arc::new(RwLock::new(logic_layer_config)))

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -126,6 +126,8 @@ fn main() -> Result<(), Error> {
     };
     let cache_arc = Arc::new(RwLock::new(cache));
 
+    println!("{:?}", has_unique_levels_properties);
+
     // Logic Layer Config
     let logic_layer_config = match env::var("TESSERACT_LOGIC_LAYER_CONFIG_FILEPATH") {
         Ok(config_path) => {
@@ -140,6 +142,8 @@ fn main() -> Result<(), Error> {
         },
         Err(_) => None
     };
+
+    println!("{:?}", has_unique_levels_properties);
 
     // Initialize Server
     server::new(

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -131,7 +131,7 @@ fn main() -> Result<(), Error> {
         Ok(config_path) => {
             let logic_layer_config = match logic_layer::read_config(&config_path) {
                 Ok(config_obj) => {
-                    has_unique_levels_properties = config_obj.has_unique_levels_properties(&schema);
+                    has_unique_levels_properties = config_obj.has_unique_levels_properties(&schema)?;
                     config_obj
                 },
                 Err(err) => return Err(err)

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -126,6 +126,8 @@ fn main() -> Result<(), Error> {
     };
     let cache_arc = Arc::new(RwLock::new(cache));
 
+//    println!("{:?}", has_unique_levels_properties);
+
     // Logic Layer Config
     let logic_layer_config = match env::var("TESSERACT_LOGIC_LAYER_CONFIG_FILEPATH") {
         Ok(config_path) => {
@@ -140,6 +142,8 @@ fn main() -> Result<(), Error> {
         },
         Err(_) => None
     };
+
+//    println!("{:?}", has_unique_levels_properties);
 
     // Initialize Server
     server::new(


### PR DESCRIPTION
Example configuration, assuming there is a `[Category].[Category].[Category]` level and a `[Category].[Category].[Category].[Name]` property:

```json
    "aliases": {
        "cubes": [
            {
                "name": "Sales",
                "alternatives": ["sales", "sale"],
                "levels": [
                    {
                        "current_name": "Category 2.Category 2.Category",
                        "unique_name": "Category 2"
                    }
                ],
                "properties": [
                    {
                        "current_name": "Category 2.Category 2.Category.Name",
                        "unique_name": "Name 2"
                    }
                ]
            }
        ]
    }
```