### PR TITLE
Rate calculation

### DIFF
--- a/tesseract-clickhouse/src/lib.rs
+++ b/tesseract-clickhouse/src/lib.rs
@@ -87,6 +87,7 @@ impl Backend for Clickhouse {
             &query_ir.limit,
             &query_ir.rca,
             &query_ir.growth,
+            &query_ir.rate,
         )
     }
 

--- a/tesseract-clickhouse/src/sql.rs
+++ b/tesseract-clickhouse/src/sql.rs
@@ -48,15 +48,19 @@ pub fn clickhouse_sql(
         if let Some(rca) = rca {
             rca::calculate(table, cuts, drills, meas, rca)
         } else {
-            primary_agg(table, cuts, drills, meas)
+            if let Some(rate) = rate {
+                rate_calculation(table, cuts, drills, meas, rate)
+            } else {
+                primary_agg(table, cuts, drills, meas)
+            }
         }
     };
 
-    if let Some(rate) = rate {
-        final_sql = rate_calculation(
-            table, cuts, drills, meas, rate, &final_sql, &final_drill_cols
-        );
-    }
+    println!(" ");
+    println!("{}", final_sql);
+    println!(" ");
+    println!("{}", final_drill_cols);
+    println!(" ");
 
     if let Some(growth) = growth {
         let (sql, drill_cols) = growth::calculate(final_sql, &final_drill_cols, meas.len(), growth);

--- a/tesseract-clickhouse/src/sql.rs
+++ b/tesseract-clickhouse/src/sql.rs
@@ -47,20 +47,12 @@ pub fn clickhouse_sql(
     let (mut final_sql, mut final_drill_cols) = {
         if let Some(rca) = rca {
             rca::calculate(table, cuts, drills, meas, rca)
+        } else if let Some(rate) = rate {
+            rate_calculation(table, cuts, drills, meas, rate)
         } else {
-            if let Some(rate) = rate {
-                rate_calculation(table, cuts, drills, meas, rate)
-            } else {
-                primary_agg(table, cuts, drills, meas)
-            }
+            primary_agg(table, cuts, drills, meas)
         }
     };
-
-    println!(" ");
-    println!("{}", final_sql);
-    println!(" ");
-    println!("{}", final_drill_cols);
-    println!(" ");
 
     if let Some(growth) = growth {
         let (sql, drill_cols) = growth::calculate(final_sql, &final_drill_cols, meas.len(), growth);

--- a/tesseract-clickhouse/src/sql.rs
+++ b/tesseract-clickhouse/src/sql.rs
@@ -1,3 +1,5 @@
+use itertools::join;
+
 mod aggregator;
 mod cuts;
 mod growth;
@@ -50,6 +52,12 @@ pub fn clickhouse_sql(
         }
     };
 
+    if let Some(rate) = rate {
+        final_sql = rate_calculation(
+            table, cuts, drills, meas, rate, &final_sql, &final_drill_cols
+        );
+    }
+
     if let Some(growth) = growth {
         let (sql, drill_cols) = growth::calculate(final_sql, &final_drill_cols, meas.len(), growth);
         final_sql = sql;
@@ -60,6 +68,68 @@ pub fn clickhouse_sql(
 
     final_sql
 }
+
+
+pub fn rate_calculation(
+    table: &TableSql,
+    cuts: &[CutSql],
+    drills: &[DrilldownSql],
+    meas: &[MeasureSql],
+    rate: &RateSql,
+    final_sql: &str,
+    final_drill_cols: &str
+) -> String
+{
+    let final_sql = final_sql.to_string().clone();
+    let final_drill_cols = final_drill_cols.to_string().clone();
+
+    let mut rate_sql = "(select ".to_string();
+    let mut drill_aliases: Vec<String> = vec![];
+
+    for drill in drills {
+        let drill_alias = &drill.col_alias_only_vec()[0];
+
+        drill_aliases.push(drill_alias.clone());
+
+        rate_sql = format!("{}{} as {}, ",
+            rate_sql, drill.primary_key.clone(), drill_alias
+        );
+    }
+
+    rate_sql = format!("{}{} as rate_col_id, {} as rate_mea from {}) as s1",
+        rate_sql, rate.column, meas[0].column, rate.table.name
+    );
+
+    rate_sql = format!("{} all inner join ({}) as s2", rate_sql, final_sql);
+
+    rate_sql = format!("select {}, rate_col_id, rate_mea, final_m0 from {} using {}",
+        final_drill_cols,
+        rate_sql,
+        join(drill_aliases, ", ")
+    );
+
+    rate_sql = format!("select {}, final_m0, groupArray(rate_col_id) as rate_col_id, groupArray(rate_mea) as rate_mea from ({}) group by {}, final_m0",
+        final_drill_cols,
+        rate_sql,
+        final_drill_cols
+    );
+
+    rate_sql = format!("select {}, rate_col_id_final, rate_mea_final, final_m0 from ({}) array join rate_col_id as rate_col_id_final, rate_mea as rate_mea_final",
+        final_drill_cols, rate_sql
+    );
+
+    rate_sql = format!("select {}, final_m0, sum(rate_mea_final) / avg(final_m0) from ({}) where rate_col_id_final in ({}) group by {}, final_m0 order by {}",
+        final_drill_cols,
+        rate_sql,
+        join(rate.members.clone(), ", "),
+        final_drill_cols,
+        final_drill_cols
+    );
+
+    rate_sql
+}
+
+
 
 // TODO test having not cuts or drilldowns
 #[cfg(test)]

--- a/tesseract-clickhouse/src/sql.rs
+++ b/tesseract-clickhouse/src/sql.rs
@@ -17,6 +17,7 @@ use tesseract_core::query_ir::{
     RcaSql,
     GrowthSql,
     FilterSql,
+    RateSql,
     dim_subquery,
 };
 use self::options::wrap_options;
@@ -38,13 +39,17 @@ pub fn clickhouse_sql(
     limit: &Option<LimitSql>,
     rca: &Option<RcaSql>,
     growth: &Option<GrowthSql>,
+    rate: &Option<RateSql>,
     ) -> String
 {
+
+    // TODO: Should rate calculation be a separate method?
+
     let (mut final_sql, mut final_drill_cols) = {
         if let Some(rca) = rca {
-            rca::calculate(table, cuts, drills, meas, rca)
+            rca::calculate(table, cuts, drills, meas, rate, rca)
         } else {
-            primary_agg(table, cuts, drills, meas)
+            primary_agg(table, cuts, drills, meas, rate)
         }
     };
 

--- a/tesseract-clickhouse/src/sql.rs
+++ b/tesseract-clickhouse/src/sql.rs
@@ -42,9 +42,6 @@ pub fn clickhouse_sql(
     rate: &Option<RateSql>,
     ) -> String
 {
-
-    // TODO: Should rate calculation be a separate method?
-
     let (mut final_sql, mut final_drill_cols) = {
         if let Some(rca) = rca {
             rca::calculate(table, cuts, drills, meas, rate, rca)

--- a/tesseract-clickhouse/src/sql/primary_agg.rs
+++ b/tesseract-clickhouse/src/sql/primary_agg.rs
@@ -167,9 +167,12 @@ pub fn primary_agg(
         fact_sql.push_str(&format!(" where {}", cut_clause));
 
         if let Some(r) = rate {
-            // TODO: Allow for multiple members
             rate_fact_sql.push_str(
-                &format!(" where {} = {} and {}", r.column.clone(), r.members.clone(), cut_clause)
+                &format!(" where {} in ({}) and {}",
+                     r.column.clone(),
+                     join(r.members.clone(), ", "),
+                     cut_clause
+                )
             );
         }
     }

--- a/tesseract-clickhouse/src/sql/primary_agg.rs
+++ b/tesseract-clickhouse/src/sql/primary_agg.rs
@@ -139,7 +139,7 @@ pub fn primary_agg(
 
     let mut rate_fact_sql = "".to_string();
 
-    if let Some(_r) = rate {
+    if rate.is_some() {
         rate_fact_sql = format!("select {}", all_fact_dim_cols);
         rate_fact_sql.push_str(&format!(", {}({}) as rate_num from {}", rate_aggregator, meas[0].column, table.name));
     }
@@ -185,7 +185,7 @@ pub fn primary_agg(
 
     fact_sql.push_str(&format!(" group by {}", all_fact_dim_aliass));
 
-    if let Some(_r) = rate {
+    if rate.is_some() {
         rate_fact_sql.push_str(&format!(" group by {}", all_fact_dim_aliass));
     }
 
@@ -231,7 +231,7 @@ pub fn primary_agg(
         );
 
         // Wrap with rate subquery if there is a rate calculation
-        if let Some(_r) = rate {
+        if rate.is_some() {
             sub_queries = format!("select {}{}, rate_num from ({}) all inner join ({}) using {}",
                 sub_queries_dim_cols,
                 select_mea_cols,

--- a/tesseract-clickhouse/src/sql/primary_agg.rs
+++ b/tesseract-clickhouse/src/sql/primary_agg.rs
@@ -132,7 +132,7 @@ pub fn primary_agg(
     let mut fact_sql = format!("select {}", all_fact_dim_cols);
     fact_sql.push_str(&format!(", {} from {}", mea_cols, table.name));
 
-    let agg = match meas[0].aggregator {
+    let rate_aggregator = match meas[0].aggregator {
         Aggregator::Count => "count".to_string(),
         _ => "sum".to_string()
     };
@@ -141,7 +141,7 @@ pub fn primary_agg(
 
     if let Some(_r) = rate {
         rate_fact_sql = format!("select {}", all_fact_dim_cols);
-        rate_fact_sql.push_str(&format!(", {}({}) as rate_num from {}", agg, meas[0].column, table.name));
+        rate_fact_sql.push_str(&format!(", {}({}) as rate_num from {}", rate_aggregator, meas[0].column, table.name));
     }
 
     if (inline_cuts.len() > 0) || (ext_cuts_for_inline.len() > 0) {
@@ -258,8 +258,8 @@ pub fn primary_agg(
             format!("select {}, {}, {}(rate_num) / {}(m0) as rate from ({}) group by {}",
                 final_drill_cols,
                 final_mea_cols,
-                agg,
-                agg,
+                rate_aggregator,
+                rate_aggregator,
                 sub_queries,
                 final_drill_cols,
             )

--- a/tesseract-clickhouse/src/sql/primary_agg.rs
+++ b/tesseract-clickhouse/src/sql/primary_agg.rs
@@ -14,8 +14,6 @@ use super::{
     dim_subquery,
 };
 
-use tesseract_core::{Aggregator};
-
 
 /// Error checking is done before this point. This string formatter
 /// accepts any input

--- a/tesseract-clickhouse/src/sql/primary_agg.rs
+++ b/tesseract-clickhouse/src/sql/primary_agg.rs
@@ -242,10 +242,6 @@ pub fn primary_agg(
         }
     }
 
-    println!(" ");
-    println!("{}", sub_queries);
-    println!(" ");
-
     // Finally, wrap with final agg and result
     let final_drill_cols = drills.iter().map(|drill| drill.col_alias_only_string());
     let final_drill_cols = join(final_drill_cols, ", ");
@@ -259,7 +255,6 @@ pub fn primary_agg(
     // This is the final result of the groupings.
     let final_sql = match rate {
         Some(_r) => {
-            // TODO: Use appropriate aggregator
             format!("select {}, {}, {}(rate_num) / {}(m0) as rate from ({}) group by {}",
                 final_drill_cols,
                 final_mea_cols,

--- a/tesseract-clickhouse/src/sql/primary_agg.rs
+++ b/tesseract-clickhouse/src/sql/primary_agg.rs
@@ -11,7 +11,6 @@ use super::{
     CutSql,
     DrilldownSql,
     MeasureSql,
-    RateSql,
     dim_subquery,
 };
 
@@ -25,7 +24,6 @@ pub fn primary_agg(
     cuts: &[CutSql],
     drills: &[DrilldownSql],
     meas: &[MeasureSql],
-    rate: &Option<RateSql>,
     ) -> (String, String)
 {
     // Before first section, need to separate out inline dims.

--- a/tesseract-clickhouse/src/sql/rate.rs
+++ b/tesseract-clickhouse/src/sql/rate.rs
@@ -8,62 +8,75 @@ use super::{
     RateSql,
 };
 
+use crate::sql::primary_agg::primary_agg;
+
+use tesseract_core::{Aggregator};
+
 
 pub fn rate_calculation(
     table: &TableSql,
     cuts: &[CutSql],
     drills: &[DrilldownSql],
     meas: &[MeasureSql],
-    rate: &RateSql,
-    final_sql: &str,
-    final_drill_cols: &str
-) -> String
+    rate: &RateSql
+) -> (String, String)
 {
-    let final_sql = final_sql.to_string().clone();
-    let final_drill_cols = final_drill_cols.to_string().clone();
-
-    let mut rate_sql = "(select ".to_string();
-    let mut drill_aliases: Vec<String> = vec![];
-
+    // Add a drilldown on the level we are getting the rate for
+    let mut new_drills: Vec<DrilldownSql> = vec![];
     for drill in drills {
-        let drill_alias = &drill.col_alias_only_vec()[0];
+        new_drills.push(drill.clone());
+    }
+    new_drills.push(rate.drilldown_sql.clone());
 
-        drill_aliases.push(drill_alias.clone());
+    // Call primary agg
+    let (mut final_sql, mut final_drill_cols) = {
+        primary_agg(table, cuts, &new_drills, meas)
+    };
 
-        rate_sql = format!("{}{} as {}, ",
-                           rate_sql, drill.primary_key.clone(), drill_alias
-        );
+    let mut rate_sql = "".to_string();
+
+    // Wrap that around a pivot
+    let original_drill_cols = drills.iter().map(|drill| drill.col_alias_only_string());
+    let original_drill_cols = join(original_drill_cols, ", ");
+
+    let rate_aggregator = match meas[0].aggregator {
+        Aggregator::Count => "count".to_string(),
+        _ => "sum".to_string()
+    };
+
+    rate_sql = format!("select {}, {}(final_m0) as final_m0_agg, groupArray(final_m0) as final_m0_rate",
+        original_drill_cols, rate_aggregator
+    );
+
+    let rate_drill_cols = rate.drilldown_sql.col_alias_only_vec();
+    for rate_drill_col in &rate_drill_cols {
+        rate_sql = format!("{}, groupArray({}) as {}", rate_sql, rate_drill_col, rate_drill_col);
     }
 
-    rate_sql = format!("{}{} as rate_col_id, {} as rate_mea from {}) as s1",
-                       rate_sql, rate.column, meas[0].column, rate.table.name
+    rate_sql = format!("{} from ({}) group by {}", rate_sql, final_sql, original_drill_cols);
+
+    // Unpivot
+    //    Watch out for the appropriate aggregation
+    rate_sql = format!("select {}, final_m0_agg as final_m0, final_m0_rate from ({}) array join",
+        final_drill_cols, rate_sql
     );
 
-    rate_sql = format!("{} all inner join ({}) as s2", rate_sql, final_sql);
+    for rate_drill_col in &rate_drill_cols {
+        rate_sql = format!("{} {} as {},", rate_sql, rate_drill_col, rate_drill_col);
+    }
 
-    rate_sql = format!("select {}, rate_col_id, rate_mea, final_m0 from {} using {}",
-                       final_drill_cols,
-                       rate_sql,
-                       join(drill_aliases, ", ")
+    rate_sql = format!("{} final_m0_rate as final_m0_rate", rate_sql);
+
+    // Final aggregation
+    rate_sql = format!("select {}, final_m0, {}(final_m0_rate) / avg(final_m0) from ({}) where {} in ({}) group by {}, final_m0 order by {}",
+        original_drill_cols,
+        rate_aggregator,
+        rate_sql,
+        rate_drill_cols[0],
+        join(rate.members.clone(), ", "),
+        original_drill_cols,
+        original_drill_cols
     );
 
-    rate_sql = format!("select {}, final_m0, groupArray(rate_col_id) as rate_col_id, groupArray(rate_mea) as rate_mea from ({}) group by {}, final_m0",
-                       final_drill_cols,
-                       rate_sql,
-                       final_drill_cols
-    );
-
-    rate_sql = format!("select {}, rate_col_id_final, rate_mea_final, final_m0 from ({}) array join rate_col_id as rate_col_id_final, rate_mea as rate_mea_final",
-                       final_drill_cols, rate_sql
-    );
-
-    rate_sql = format!("select {}, final_m0, sum(rate_mea_final) / avg(final_m0) from ({}) where rate_col_id_final in ({}) group by {}, final_m0 order by {}",
-                       final_drill_cols,
-                       rate_sql,
-                       join(rate.members.clone(), ", "),
-                       final_drill_cols,
-                       final_drill_cols
-    );
-
-    rate_sql
+    (rate_sql, original_drill_cols)
 }

--- a/tesseract-clickhouse/src/sql/rate.rs
+++ b/tesseract-clickhouse/src/sql/rate.rs
@@ -27,12 +27,6 @@ pub fn rate_calculation(
 
     for drill in drills {
         if drill == &rate.drilldown_sql {
-//            found_rate_drill = true;
-
-            println!(" ");
-            println!("CONTINUING...");
-            println!(" ");
-
             continue;
         }
         new_drills.push(drill.clone());

--- a/tesseract-clickhouse/src/sql/rate.rs
+++ b/tesseract-clickhouse/src/sql/rate.rs
@@ -1,0 +1,69 @@
+use itertools::join;
+
+use super::{
+    TableSql,
+    CutSql,
+    DrilldownSql,
+    MeasureSql,
+    RateSql,
+};
+
+
+pub fn rate_calculation(
+    table: &TableSql,
+    cuts: &[CutSql],
+    drills: &[DrilldownSql],
+    meas: &[MeasureSql],
+    rate: &RateSql,
+    final_sql: &str,
+    final_drill_cols: &str
+) -> String
+{
+    let final_sql = final_sql.to_string().clone();
+    let final_drill_cols = final_drill_cols.to_string().clone();
+
+    let mut rate_sql = "(select ".to_string();
+    let mut drill_aliases: Vec<String> = vec![];
+
+    for drill in drills {
+        let drill_alias = &drill.col_alias_only_vec()[0];
+
+        drill_aliases.push(drill_alias.clone());
+
+        rate_sql = format!("{}{} as {}, ",
+                           rate_sql, drill.primary_key.clone(), drill_alias
+        );
+    }
+
+    rate_sql = format!("{}{} as rate_col_id, {} as rate_mea from {}) as s1",
+                       rate_sql, rate.column, meas[0].column, rate.table.name
+    );
+
+    rate_sql = format!("{} all inner join ({}) as s2", rate_sql, final_sql);
+
+    rate_sql = format!("select {}, rate_col_id, rate_mea, final_m0 from {} using {}",
+                       final_drill_cols,
+                       rate_sql,
+                       join(drill_aliases, ", ")
+    );
+
+    rate_sql = format!("select {}, final_m0, groupArray(rate_col_id) as rate_col_id, groupArray(rate_mea) as rate_mea from ({}) group by {}, final_m0",
+                       final_drill_cols,
+                       rate_sql,
+                       final_drill_cols
+    );
+
+    rate_sql = format!("select {}, rate_col_id_final, rate_mea_final, final_m0 from ({}) array join rate_col_id as rate_col_id_final, rate_mea as rate_mea_final",
+                       final_drill_cols, rate_sql
+    );
+
+    rate_sql = format!("select {}, final_m0, sum(rate_mea_final) / avg(final_m0) from ({}) where rate_col_id_final in ({}) group by {}, final_m0 order by {}",
+                       final_drill_cols,
+                       rate_sql,
+                       join(rate.members.clone(), ", "),
+                       final_drill_cols,
+                       final_drill_cols
+    );
+
+    rate_sql
+}

--- a/tesseract-clickhouse/src/sql/rca.rs
+++ b/tesseract-clickhouse/src/sql/rca.rs
@@ -280,4 +280,3 @@ pub fn calculate(
 
     (final_sql, a_final_drills)
 }
-

--- a/tesseract-clickhouse/src/sql/rca.rs
+++ b/tesseract-clickhouse/src/sql/rca.rs
@@ -44,7 +44,6 @@ use super::{
     CutSql,
     DrilldownSql,
     MeasureSql,
-    RateSql,
     RcaSql,
 };
 
@@ -53,7 +52,6 @@ pub fn calculate(
     cuts: &[CutSql],
     drills: &[DrilldownSql],
     meas: &[MeasureSql],
-    rate: &Option<RateSql>,
     rca: &RcaSql,
     ) -> (String, String)
 {
@@ -134,8 +132,8 @@ pub fn calculate(
     // If there's no internal cuts, then b, c, d are calculated from a.
 
     // First do aggregation for part a, b
-    let (a, a_final_drills) = primary_agg(table, &ac_cuts, &a_drills, &all_meas, &rate);
-    let (b, b_final_drills) = primary_agg(table, &bd_cuts, &b_drills, &all_meas, &rate);
+    let (a, a_final_drills) = primary_agg(table, &ac_cuts, &a_drills, &all_meas);
+    let (b, b_final_drills) = primary_agg(table, &bd_cuts, &b_drills, &all_meas);
 
     // replace final_m0 with letter name.
     // I put the rca measure at the beginning of the drills, so it should

--- a/tesseract-clickhouse/src/sql/rca.rs
+++ b/tesseract-clickhouse/src/sql/rca.rs
@@ -44,6 +44,7 @@ use super::{
     CutSql,
     DrilldownSql,
     MeasureSql,
+    RateSql,
     RcaSql,
 };
 
@@ -52,6 +53,7 @@ pub fn calculate(
     cuts: &[CutSql],
     drills: &[DrilldownSql],
     meas: &[MeasureSql],
+    rate: &Option<RateSql>,
     rca: &RcaSql,
     ) -> (String, String)
 {
@@ -132,8 +134,8 @@ pub fn calculate(
     // If there's no internal cuts, then b, c, d are calculated from a.
 
     // First do aggregation for part a, b
-    let (a, a_final_drills) = primary_agg(table, &ac_cuts, &a_drills, &all_meas);
-    let (b, b_final_drills) = primary_agg(table, &bd_cuts, &b_drills, &all_meas);
+    let (a, a_final_drills) = primary_agg(table, &ac_cuts, &a_drills, &all_meas, &rate);
+    let (b, b_final_drills) = primary_agg(table, &bd_cuts, &b_drills, &all_meas, &rate);
 
     // replace final_m0 with letter name.
     // I put the rca measure at the beginning of the drills, so it should

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -406,7 +406,7 @@ impl Schema {
             Some(RateSql {
                 table: members_query_ir.table,
                 column: members_query_ir.key_column,
-                members: rate.value.clone()
+                members: rate.values.clone()
             })
         } else {
             None

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -411,12 +411,14 @@ impl Schema {
                 _ => return Err(format_err!("Rate can only be calculated for measures with sum or count aggregations"))
             }
 
-            let members_query_ir = self.get_dim_col_table(cube, &rate.level_name)?;
+            let drilldown_sql = self.cube_drill_cols(
+                &cube, &[Drilldown(rate.level_name.clone())],
+                &query.properties, &query.captions, query.parents
+            )?;
 
             Some(RateSql {
-                table: members_query_ir.table,
-                column: members_query_ir.key_column,
-                members: rate.values.clone()
+                drilldown_sql: drilldown_sql[0].clone(),
+                members: rate.values.clone(),
             })
         } else {
             None
@@ -484,7 +486,7 @@ impl Schema {
         };
 
         // Rate calculations always come last
-        if let Some(ref rate) = query.rate {
+        if query.rate.is_some() {
             headers.push("Rate".to_string());
         }
 

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -394,12 +394,28 @@ impl Schema {
         };
 
         let rate = if let Some(ref rate) = query.rate {
-            // TODO: Perform drills and cols checks here
+            // For now at least, we'll allow drilldowns and cuts on the level
+            // used for the rate calculation. Drilldowns will always result in
+            // a rate of 1. Cuts allow for rate calculation in a subset of the
+            // level universe (for example, calculating the rate of "Non-fiction"
+            // sales inside a "Books" named set.
 
             // Only one measure allowed when getting rates for now
             if mea_cols.len() > 1 {
                 return Err(format_err!("Only one measure allowed for rate calculations"));
             }
+
+            match mea_cols[0].aggregator {
+                Aggregator::Sum => (),
+                Aggregator::Count => (),
+                _ => return Err(format_err!("Rate can only be calculated for measures with sum or count aggregations"))
+            }
+
+            println!(" ");
+            println!(" ");
+            println!("{:?}", mea_cols);
+            println!(" ");
+            println!(" ");
 
             let members_query_ir = self.get_dim_col_table(cube, &rate.level_name)?;
 

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -411,12 +411,6 @@ impl Schema {
                 _ => return Err(format_err!("Rate can only be calculated for measures with sum or count aggregations"))
             }
 
-            println!(" ");
-            println!(" ");
-            println!("{:?}", mea_cols);
-            println!(" ");
-            println!(" ");
-
             let members_query_ir = self.get_dim_col_table(cube, &rate.level_name)?;
 
             Some(RateSql {

--- a/tesseract-core/src/query.rs
+++ b/tesseract-core/src/query.rs
@@ -444,3 +444,23 @@ impl FromStr for FilterQuery {
         }
     }
 }
+
+
+#[derive(Debug, Clone)]
+pub struct RateQuery {
+    pub level_name: LevelName,
+    pub value: String,
+    pub measure: Measure,
+}
+
+impl RateQuery {
+    pub fn new(level_name: LevelName, value: String, measure: String) -> Self {
+        let measure = Measure::new(measure);
+
+        RateQuery {
+            level_name,
+            value,
+            measure,
+        }
+    }
+}

--- a/tesseract-core/src/query.rs
+++ b/tesseract-core/src/query.rs
@@ -24,6 +24,7 @@ pub struct Query {
     pub limit: Option<LimitQuery>,
     pub rca: Option<RcaQuery>,
     pub growth: Option<GrowthQuery>,
+    pub rate: Option<RateQuery>,
     pub debug: bool,
 }
 
@@ -43,6 +44,7 @@ impl Query {
             limit: None,
             rca: None,
             growth: None,
+            rate: None,
             debug: false,
         }
     }
@@ -450,17 +452,13 @@ impl FromStr for FilterQuery {
 pub struct RateQuery {
     pub level_name: LevelName,
     pub value: String,
-    pub measure: Measure,
 }
 
 impl RateQuery {
-    pub fn new(level_name: LevelName, value: String, measure: String) -> Self {
-        let measure = Measure::new(measure);
-
+    pub fn new(level_name: LevelName, value: String) -> Self {
         RateQuery {
             level_name,
             value,
-            measure,
         }
     }
 }

--- a/tesseract-core/src/query.rs
+++ b/tesseract-core/src/query.rs
@@ -1,3 +1,5 @@
+use itertools::join;
+
 use failure::{Error, format_err, bail};
 use std::str::FromStr;
 
@@ -460,5 +462,27 @@ impl RateQuery {
             level_name,
             values,
         }
+    }
+}
+
+impl FromStr for RateQuery {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rate_split: Vec<String> = s.split(".").map(|x| x.to_string()).collect();
+        let n = rate_split.len();
+
+        if n <= 2 || n >= 5 {
+            return Err(format_err!("Malformatted RateQuery"));
+        }
+
+        let level = join(rate_split[0..n-1].iter(), ".");
+        let level_name = level.parse::<LevelName>()?;
+        let values: Vec<String> = rate_split[n-1].split(",").map(|s| s.to_string()).collect();
+
+        Ok(RateQuery{
+            level_name,
+            values
+        })
     }
 }

--- a/tesseract-core/src/query.rs
+++ b/tesseract-core/src/query.rs
@@ -451,14 +451,14 @@ impl FromStr for FilterQuery {
 #[derive(Debug, Clone)]
 pub struct RateQuery {
     pub level_name: LevelName,
-    pub value: String,
+    pub values: Vec<String>,
 }
 
 impl RateQuery {
-    pub fn new(level_name: LevelName, value: String) -> Self {
+    pub fn new(level_name: LevelName, values: Vec<String>) -> Self {
         RateQuery {
             level_name,
-            value,
+            values,
         }
     }
 }

--- a/tesseract-core/src/query_ir.rs
+++ b/tesseract-core/src/query_ir.rs
@@ -309,13 +309,8 @@ pub struct GrowthSql {
 
 #[derive(Debug, Clone)]
 pub struct RateSql {
-    pub table: Table,
-//    pub primary_key: String,
-//    pub foreign_key: String,
-    pub column: String,
+    pub drilldown_sql: DrilldownSql,
     pub members: Vec<String>,
-//    pub member_type: MemberType,
-//    pub inline_table: Option<InlineTable>,
 }
 
 #[derive(Debug, Clone)]

--- a/tesseract-core/src/query_ir.rs
+++ b/tesseract-core/src/query_ir.rs
@@ -21,6 +21,7 @@ pub struct QueryIr {
     pub limit: Option<LimitSql>,
     pub rca: Option<RcaSql>,
     pub growth: Option<GrowthSql>,
+    pub rate: Option<RateSql>,
 }
 
 #[derive(Debug, Clone)]
@@ -304,6 +305,18 @@ pub struct RcaSql {
 pub struct GrowthSql {
     pub time_drill: DrilldownSql,
     pub mea: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RateSql {
+    pub table: Table,
+//    pub primary_key: String,
+//    pub foreign_key: String,
+    pub column: String,
+    pub members: String,
+//    pub members: Vec<String>,
+//    pub member_type: MemberType,
+//    pub inline_table: Option<InlineTable>,
 }
 
 #[derive(Debug, Clone)]

--- a/tesseract-core/src/query_ir.rs
+++ b/tesseract-core/src/query_ir.rs
@@ -313,8 +313,7 @@ pub struct RateSql {
 //    pub primary_key: String,
 //    pub foreign_key: String,
     pub column: String,
-    pub members: String,
-//    pub members: Vec<String>,
+    pub members: Vec<String>,
 //    pub member_type: MemberType,
 //    pub inline_table: Option<InlineTable>,
 }

--- a/tesseract-core/src/schema/aggregator.rs
+++ b/tesseract-core/src/schema/aggregator.rs
@@ -30,14 +30,12 @@ pub enum Aggregator {
     #[serde(rename="weighted_sum")]
     WeightedSum {
         weight_column: String,
-
     },
     /// Weighted Average is calculated against the measure's value column.
     /// sum(column * weight_column) / sum(weight_column)
     #[serde(rename="weighted_avg")]
     WeightedAverage {
         weight_column: String,
-
     },
     /// Where the measure column is the primary value,
     /// and a list of secondary column is provided to the MO aggregator:

--- a/tesseract-server/src/handlers/aggregate.rs
+++ b/tesseract-server/src/handlers/aggregate.rs
@@ -223,6 +223,7 @@ impl TryFrom<AggregateQueryOpt> for TsQuery {
 
         let debug = agg_query_opt.debug.unwrap_or(false);
 
+        // TODO: deserialize rate
         Ok(TsQuery {
             drilldowns,
             cuts,

--- a/tesseract-server/src/handlers/aggregate.rs
+++ b/tesseract-server/src/handlers/aggregate.rs
@@ -238,6 +238,7 @@ impl TryFrom<AggregateQueryOpt> for TsQuery {
             rca,
             growth,
             debug,
+            rate: None
         })
     }
 }

--- a/tesseract-server/src/handlers/aggregate.rs
+++ b/tesseract-server/src/handlers/aggregate.rs
@@ -145,6 +145,7 @@ pub struct AggregateQueryOpt {
     limit: Option<String>,
     growth: Option<String>,
     rca: Option<String>,
+    rate: Option<String>,
     debug: Option<bool>,
 //    distinct: Option<bool>,
 //    nonempty: Option<bool>,
@@ -221,6 +222,10 @@ impl TryFrom<AggregateQueryOpt> for TsQuery {
             .map(|r| r.parse())
             .transpose()?;
 
+        let rate = agg_query_opt.rate
+            .map(|r| r.parse())
+            .transpose()?;
+
         let debug = agg_query_opt.debug.unwrap_or(false);
 
         // TODO: deserialize rate
@@ -239,7 +244,7 @@ impl TryFrom<AggregateQueryOpt> for TsQuery {
             rca,
             growth,
             debug,
-            rate: None
+            rate
         })
     }
 }

--- a/tesseract-server/src/handlers/logic_layer/shared.rs
+++ b/tesseract-server/src/handlers/logic_layer/shared.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use serde_derive::Deserialize;
 
-use tesseract_core::names::{Cut, Drilldown, Property, Measure, LevelName};
+use tesseract_core::names::{Cut, Drilldown, Property, Measure};
 use tesseract_core::query::{FilterQuery, GrowthQuery, RcaQuery, TopQuery, RateQuery};
 use tesseract_core::{Query as TsQuery, Schema, MeaOrCalc};
 use tesseract_core::schema::{Cube};
@@ -212,24 +212,6 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
         let ll_config = agg_query_opt.config.clone();
 
         let parents = agg_query_opt.parents.unwrap_or(false);
-
-        let rate = match agg_query_opt.rate {
-            Some(rate) => {
-                let level_value_split: Vec<String> = rate.split(".").map(|s| s.to_string()).collect();
-                if level_value_split.len() != 2 {
-                    bail!("Malformatted rate calculation specification.");
-                }
-
-                let level_name = match level_map.get(&level_value_split[0]) {
-                    Some(level_name) => level_name.clone(),
-                    None => bail!("Unrecognized level in rate calculation.")
-                };
-                let value = level_value_split[1].clone();
-
-                Some(RateQuery::new(level_name, value))
-            },
-            None => None
-        };
 
         let drilldowns: Vec<_> = agg_query_opt.drilldowns
             .map(|ds| {
@@ -493,6 +475,24 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
                 );
 
                 Some(rca)
+            },
+            None => None
+        };
+
+        let rate = match agg_query_opt.rate {
+            Some(rate) => {
+                let level_value_split: Vec<String> = rate.split(".").map(|s| s.to_string()).collect();
+                if level_value_split.len() != 2 {
+                    bail!("Malformatted rate calculation specification.");
+                }
+
+                let level_name = match level_map.get(&level_value_split[0]) {
+                    Some(level_name) => level_name.clone(),
+                    None => bail!("Unrecognized level in rate calculation.")
+                };
+                let value = level_value_split[1].clone();
+
+                Some(RateQuery::new(level_name, value))
             },
             None => None
         };

--- a/tesseract-server/src/handlers/logic_layer/shared.rs
+++ b/tesseract-server/src/handlers/logic_layer/shared.rs
@@ -479,6 +479,7 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
             None => None
         };
 
+        // TODO: Resolve named sets
         let rate = match agg_query_opt.rate {
             Some(rate) => {
                 let level_value_split: Vec<String> = rate.split(".").map(|s| s.to_string()).collect();
@@ -492,7 +493,9 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
                 };
                 let value = level_value_split[1].clone();
 
-                Some(RateQuery::new(level_name, value))
+                let values: Vec<String> = value.split(",").map(|s| s.to_string()).collect();
+
+                Some(RateQuery::new(level_name, values))
             },
             None => None
         };


### PR DESCRIPTION
This first version only allows 1 measure defined when a rate param is received. That measure is required to have either a sum or count aggregator and is used to calculate the rate.

Other than that, the raw Tesseract syntax is `rate=Dim.Hier.Level.val_1` and the logic layer syntax is `rate=Level.val_1`.

Multiple values can be passed in separated by commas: `rate=Level.val_1,val_2`.

For now, at least, we'll allow drilldowns and cuts on the level used for the rate calculation. Drilldowns will always result in a rate of 1. Cuts allow for rate calculation in a subset of the level universe (for example, calculating the rate of "Non-fiction" sales inside a "Books" named set.