### PR TITLE
adds cube and dimension name to default hierarchy error message

### DIFF
--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -107,7 +107,7 @@ impl Schema {
                     // first, default_hierarchy must be assigned
                     let default_hierarchy = dim.default_hierarchy
                         .clone()
-                        .ok_or_else(|| format_err!("Default hierarchy required for multiple hierarchies in cube: {} dimension: {}", &cube_name, &dim.name))?;
+                        .ok_or_else(|| format_err!("Default hierarchy required for multiple hierarchies in cube: {} dimension: {}", cube_name, &dim.name))?;
 
                     // if default_hierarchy exists, then check that it's in one of the
                     // hierarchies

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -103,10 +103,11 @@ impl Schema {
                 if dim.hierarchies.len() == 1 {
                     dim.default_hierarchy = None;
                 } else if !dim.hierarchies.is_empty() {
+                    let cube_name = &cube.name;
                     // first, default_hierarchy must be assigned
                     let default_hierarchy = dim.default_hierarchy
                         .clone()
-                        .ok_or_else(|| format_err!("Default hierarchy required for multiple hierarchies"))?;
+                        .ok_or_else(|| format_err!("Default hierarchy required for multiple hierarchies in cube: {} dimension: {}", &cube_name, &dim.name))?;
 
                     // if default_hierarchy exists, then check that it's in one of the
                     // hierarchies


### PR DESCRIPTION
Currently, when a tesseract user has a dimension with multiple hierarchies and doesn't specify a default, the error doesn't say where the issue is happening. So this PR adds a little extra info to make it easier to track down.

(Not crazy about the extra `cube_name = &cube.name` but was the easiest interim fix for working around double borrowing issue inside closure -- so feel free to suggest alternatives)