### PR TITLE
Adds new default member feature for hierarchies

### DIFF
--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -207,7 +207,7 @@ impl Schema {
     ///
     /// If the function runs in negate mode, it will add or remove a ~ from the front of the default member
     /// cut string to flip the logic in order to exclude the default member from being returned in queries.
-    fn build_default_member_cuts(&self, schema_cube: &Cube, query: &Query, negate: bool) -> Box<Vec<Cut>> {
+    fn build_default_member_cuts(&self, schema_cube: &Cube, query: &Query, negate: bool) -> Vec<Cut> {
         let target_dims = self.get_dims_for_default_member(schema_cube, query, negate);
         let result = target_dims.iter().map(|dim| {
             let target_hierarchy_name = match &dim.default_hierarchy {
@@ -233,7 +233,7 @@ impl Schema {
                 None => Err(format_err!("Bad default member"))
             }
         }).filter_map(Result::ok).collect();
-        return Box::new(result);
+        return result;
     }
 
     /// Helper function for build_default_member_cuts to get a list of dimensions.

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -207,7 +207,7 @@ impl Schema {
     ///
     /// If the function runs in negate mode, it will add or remove a ~ from the front of the default member
     /// cut string to flip the logic in order to exclude the default member from being returned in queries.
-    fn build_default_member_cuts(&self, schema_cube: &Cube, query: &Query, negate: bool) -> Vec<Cut> {
+    fn build_default_member_cuts(&self, schema_cube: &Cube, query: &Query, negate: bool) -> Result<Vec<Cut>, Error> {
         let target_dims = self.get_dims_for_default_member(schema_cube, query, negate);
         let result = target_dims.iter().map(|dim| {
             let target_hierarchy_name = match &dim.default_hierarchy {
@@ -221,18 +221,21 @@ impl Schema {
                 Some(val) => {
                     let mut new_cut_str: String = val.to_string();
                     if negate {
-                        let first_ch = new_cut_str.chars().next().expect("Expected at least one character in default member");
+                        let first_ch_opt = new_cut_str.chars().next();
+                        let first_ch = first_ch_opt.ok_or_else(|| format_err!("Expected at least one character in default member"))?;
                         new_cut_str = match first_ch {
                             '~' => new_cut_str[1..].to_string(),
                             _ => format!("~{}", new_cut_str)
                         }
-
                     }
                     Cut::from_str(&new_cut_str)
                 },
-                None => Err(format_err!("Bad default member"))
+                None => {
+                    return Err(format_err!("Bad default member"))
+                }
             }
-        }).filter_map(Result::ok).collect();
+        }).collect();
+
         return result;
     }
 
@@ -383,13 +386,13 @@ impl Schema {
 
         cut_cols.extend_from_slice(&default_hierarchy_cut_cols);
 
-        let default_member_cuts_query = self.build_default_member_cuts(schema_cube, query, false);
+        let default_member_cuts_query = self.build_default_member_cuts(schema_cube, query, false)?;
         let default_member_cut_cols = self.cube_cut_cols(&cube, &default_member_cuts_query)
             .map_err(|err| format_err!("Error creating cuts for default member: {}", err))?;
         cut_cols.extend_from_slice(&default_member_cut_cols);
 
         if query.exclude_default_members {
-            let exclude_default_member_cuts_query = self.build_default_member_cuts(schema_cube, query, true);
+            let exclude_default_member_cuts_query = self.build_default_member_cuts(schema_cube, query, true)?;
             let exclude_default_member_cut_cols = self.cube_cut_cols(&cube, &exclude_default_member_cuts_query)
                 .map_err(|err| format_err!("Error creating exclude cuts for default member: {}", err))?;
             cut_cols.extend_from_slice(&exclude_default_member_cut_cols);

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -376,7 +376,7 @@ impl Schema {
             .map_err(|err| format_err!("Error creating cuts for default member: {}", err))?;
         cut_cols.extend_from_slice(&default_member_cut_cols);
 
-        if query.exclude_default_member_in_drilldown {
+        if query.exclude_default_members {
             let exclude_default_member_cuts_query = self.build_default_member_cuts(schema_cube, query, true);
             let exclude_default_member_cut_cols = self.cube_cut_cols(&cube, &exclude_default_member_cuts_query)
                 .map_err(|err| format_err!("Error creating exclude cuts for default member: {}", err))?;

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -197,7 +197,7 @@ impl Schema {
     }
 
     fn build_default_member_cuts(&self, schema_cube: &Cube, query: &Query, negate: bool) -> Box<Vec<Cut>> {
-        let target_dims: Vec<Dimension> = self.get_dims_for_default_member(schema_cube, query, negate);
+        let target_dims = self.get_dims_for_default_member(schema_cube, query, negate);
         let result = target_dims.iter().map(|dim| {
             let target_hierarchy_name = match &dim.default_hierarchy {
                 Some(hierarchy_name) => hierarchy_name,
@@ -225,8 +225,8 @@ impl Schema {
         return Box::new(result);
     }
 
-    fn get_dims_for_default_member(&self, schema_cube: &Cube, query: &Query, negate: bool) -> Vec<Dimension> {
-        let dims: Vec<Dimension> = schema_cube.dimensions.iter()
+    fn get_dims_for_default_member<'a>(&self, schema_cube: &'a Cube, query: &Query, negate: bool) -> Vec<&'a Dimension> {
+        let dims = schema_cube.dimensions.iter()
             .filter(|dim| {
                 // filter out dims that have a drilldown or cut
                 let dim_contains_drill = query.drilldowns.iter()
@@ -245,7 +245,6 @@ impl Schema {
             // OR have only one hierarchy
             // TODO raise error if default member is set and there is no clear default hierarchy
             .filter(|dim| dim.default_hierarchy.is_some() || dim.hierarchies.len() == 1)
-            .map(|d| d.clone())
             .collect();
         dims
     }

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -1239,4 +1239,25 @@ mod test {
         schema.validate().unwrap();
         println!("{:#?}", schema);
     }
+
+    #[test]
+    fn test_basic_default_member() {
+        let s = r##"
+            <Schema name="my_schema">
+                <Cube name="my_cube">
+                    <Table name="my_table" />
+                    <Dimension foreign_key="race" name="Race">
+                        <Hierarchy name="Race" primary_key="race" default_member="Race.Race.Race.Total">
+                            <Level name="Race" key_column="race" key_type="text"/>
+                        </Hierarchy>
+                    </Dimension>
+                    <Measure name="my_mea" column="mea" aggregator="sum" />
+                </Cube>
+            </Schema>
+        "##;
+        let schema: Schema = Schema::from_xml(s).unwrap();
+        println!("{:#?}", schema);
+        let dm = schema.cubes[0].dimensions[0].hierarchies[0].default_member.clone();
+        assert_eq!(dm.unwrap(), "Race.Race.Race.Total".to_owned());
+    }
 }

--- a/tesseract-core/src/query.rs
+++ b/tesseract-core/src/query.rs
@@ -28,7 +28,7 @@ pub struct Query {
     pub growth: Option<GrowthQuery>,
     pub rate: Option<RateQuery>,
     pub debug: bool,
-    pub exclude_default_member_in_drilldown: bool,
+    pub exclude_default_members: bool,
 }
 
 impl Query {
@@ -49,7 +49,7 @@ impl Query {
             growth: None,
             rate: None,
             debug: false,
-            exclude_default_member_in_drilldown: false,
+            exclude_default_members: false,
         }
     }
 }

--- a/tesseract-core/src/query.rs
+++ b/tesseract-core/src/query.rs
@@ -28,6 +28,7 @@ pub struct Query {
     pub growth: Option<GrowthQuery>,
     pub rate: Option<RateQuery>,
     pub debug: bool,
+    pub exclude_default_member_in_drilldown: bool,
 }
 
 impl Query {
@@ -48,6 +49,7 @@ impl Query {
             growth: None,
             rate: None,
             debug: false,
+            exclude_default_member_in_drilldown: false,
         }
     }
 }

--- a/tesseract-core/src/schema.rs
+++ b/tesseract-core/src/schema.rs
@@ -337,6 +337,7 @@ pub struct Hierarchy {
     pub levels: Vec<Level>,
     pub annotations: Option<Vec<Annotation>>,
     pub inline_table: Option<InlineTable>,
+    pub default_member: Option<String>,
 }
 
 impl From<HierarchyConfigJson> for Hierarchy {
@@ -368,6 +369,7 @@ impl From<HierarchyConfigJson> for Hierarchy {
             levels,
             annotations,
             inline_table: hierarchy_config.inline_table.map(|t| t.into()),
+            default_member: hierarchy_config.default_member
         }
     }
 }

--- a/tesseract-core/src/schema.rs
+++ b/tesseract-core/src/schema.rs
@@ -660,10 +660,12 @@ mod test {
                             ],
                             annotations: None,
                             inline_table: None,
+                            default_member: None,
                         },
                     ],
                     default_hierarchy: None,
                     annotations: None,
+                    dim_type: None,
                 }
             ]),
             cubes: vec![

--- a/tesseract-core/src/schema/json.rs
+++ b/tesseract-core/src/schema/json.rs
@@ -60,6 +60,7 @@ pub struct HierarchyConfigJson {
     pub levels: Vec<LevelConfigJson>,
     pub annotations: Option<Vec<AnnotationConfigJson>>,
     pub inline_table: Option<InlineTableJson>,
+    pub default_member: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]

--- a/tesseract-core/src/schema/xml.rs
+++ b/tesseract-core/src/schema/xml.rs
@@ -89,6 +89,7 @@ pub struct HierarchyConfigXML {
     pub annotations: Option<Vec<AnnotationConfigXML>>,
     #[serde(rename(deserialize="InlineTable"))]
     pub inline_table: Option<InlineTableXML>,
+    pub default_member: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/tesseract-server/src/handlers/aggregate.rs
+++ b/tesseract-server/src/handlers/aggregate.rs
@@ -147,7 +147,7 @@ pub struct AggregateQueryOpt {
     rca: Option<String>,
     rate: Option<String>,
     debug: Option<bool>,
-    exclude_default_member_in_drilldown: Option<bool>,
+    exclude_default_members: Option<bool>,
 //    distinct: Option<bool>,
 //    nonempty: Option<bool>,
 //    sparse: Option<bool>,
@@ -228,7 +228,7 @@ impl TryFrom<AggregateQueryOpt> for TsQuery {
             .transpose()?;
 
         let debug = agg_query_opt.debug.unwrap_or(false);
-        let exclude_default_member_in_drilldown = agg_query_opt.exclude_default_member_in_drilldown.unwrap_or(false);
+        let exclude_default_members = agg_query_opt.exclude_default_members.unwrap_or(false);
 
         // TODO: deserialize rate
         Ok(TsQuery {
@@ -246,7 +246,7 @@ impl TryFrom<AggregateQueryOpt> for TsQuery {
             rca,
             growth,
             debug,
-            exclude_default_member_in_drilldown,
+            exclude_default_members,
             rate
         })
     }

--- a/tesseract-server/src/handlers/aggregate.rs
+++ b/tesseract-server/src/handlers/aggregate.rs
@@ -147,6 +147,7 @@ pub struct AggregateQueryOpt {
     rca: Option<String>,
     rate: Option<String>,
     debug: Option<bool>,
+    exclude_default_member_in_drilldown: Option<bool>,
 //    distinct: Option<bool>,
 //    nonempty: Option<bool>,
 //    sparse: Option<bool>,
@@ -227,6 +228,7 @@ impl TryFrom<AggregateQueryOpt> for TsQuery {
             .transpose()?;
 
         let debug = agg_query_opt.debug.unwrap_or(false);
+        let exclude_default_member_in_drilldown = agg_query_opt.exclude_default_member_in_drilldown.unwrap_or(false);
 
         // TODO: deserialize rate
         Ok(TsQuery {
@@ -244,6 +246,7 @@ impl TryFrom<AggregateQueryOpt> for TsQuery {
             rca,
             growth,
             debug,
+            exclude_default_member_in_drilldown,
             rate
         })
     }

--- a/tesseract-server/src/handlers/logic_layer/shared.rs
+++ b/tesseract-server/src/handlers/logic_layer/shared.rs
@@ -137,7 +137,7 @@ pub struct LogicLayerQueryOpt {
     growth: Option<String>,
     rca: Option<String>,
     debug: Option<bool>,
-    exclude_default_member_in_drilldown: Option<bool>,
+    exclude_default_members: Option<bool>,
     locale: Option<String>,
 //    distinct: Option<bool>,
 //    nonempty: Option<bool>,
@@ -502,7 +502,7 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
         };
 
         let debug = agg_query_opt.debug.unwrap_or(false);
-        let exclude_default_member_in_drilldown = agg_query_opt.exclude_default_member_in_drilldown.unwrap_or(false);
+        let exclude_default_members = agg_query_opt.exclude_default_members.unwrap_or(false);
 
         Ok(TsQuery {
             drilldowns,
@@ -518,7 +518,7 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
             rca,
             growth,
             debug,
-            exclude_default_member_in_drilldown,
+            exclude_default_members,
             filters,
             rate
         })

--- a/tesseract-server/src/handlers/logic_layer/shared.rs
+++ b/tesseract-server/src/handlers/logic_layer/shared.rs
@@ -137,6 +137,7 @@ pub struct LogicLayerQueryOpt {
     growth: Option<String>,
     rca: Option<String>,
     debug: Option<bool>,
+    exclude_default_member_in_drilldown: Option<bool>,
     locale: Option<String>,
 //    distinct: Option<bool>,
 //    nonempty: Option<bool>,
@@ -501,6 +502,7 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
         };
 
         let debug = agg_query_opt.debug.unwrap_or(false);
+        let exclude_default_member_in_drilldown = agg_query_opt.exclude_default_member_in_drilldown.unwrap_or(false);
 
         Ok(TsQuery {
             drilldowns,
@@ -516,6 +518,7 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
             rca,
             growth,
             debug,
+            exclude_default_member_in_drilldown,
             filters,
             rate
         })


### PR DESCRIPTION
The goal of this feature is to handle certain cases in data sets where "Total" rows may exist alongside other disaggregate values.

e.g.  assuming a data table `dm_test` that looked like

|Year|Race|Value|
|--|--|--|
|2017|Total|11|  
|2017|A|5|
|2017|B|5|  

The following XML would allow the definition of a default_member

```xml
  <Cube name="DM">

    <Table name="dm_test"/>

    <Dimension foreign_key="year" name="Year">
      <Hierarchy name="Year" primary_key="year">
        <Level name="Year" key_column="year" />
      </Hierarchy>
    </Dimension>

    <Dimension foreign_key="race" name="Race">
      <Hierarchy name="Race" primary_key="race" default_member="Race.Race.Race.Total">
        <Level name="Race" key_column="race" key_type="text"/>
      </Hierarchy>
    </Dimension>

    <Measure name="Value" column="value" aggregator="sum" />
  </Cube>
```

This can be tested via

http://localhost:7777/data?cube=DM&drilldowns=Year&measures=Value

Another feature is the ability to exclude the default member in drilldowns via:

http://localhost:7777/data?cube=DM&drilldowns=Race&measures=Value&exclude_default_members=true

Fixes #148 