### PR TITLE
Adds sparse feature to support filtering rows where all measures are null

### DIFF
--- a/tesseract-clickhouse/src/lib.rs
+++ b/tesseract-clickhouse/src/lib.rs
@@ -76,19 +76,7 @@ impl Backend for Clickhouse {
 
     fn generate_sql(&self, query_ir: QueryIr) -> String {
         clickhouse_sql(
-            &query_ir.table,
-            &query_ir.cuts,
-            &query_ir.drills,
-            &query_ir.meas,
-            &query_ir.hidden_drills,
-            &query_ir.filters,
-            &query_ir.top,
-            &query_ir.top_where,
-            &query_ir.sort,
-            &query_ir.limit,
-            &query_ir.rca,
-            &query_ir.growth,
-            &query_ir.rate,
+            &query_ir
         )
     }
 

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -642,6 +642,7 @@ impl Schema {
                 rca,
                 growth,
                 rate,
+                sparse: query.sparse,
             },
             headers,
         ))

--- a/tesseract-core/src/query.rs
+++ b/tesseract-core/src/query.rs
@@ -28,6 +28,7 @@ pub struct Query {
     pub growth: Option<GrowthQuery>,
     pub rate: Option<RateQuery>,
     pub debug: bool,
+    pub sparse: bool,
 }
 
 impl Query {
@@ -48,6 +49,7 @@ impl Query {
             growth: None,
             rate: None,
             debug: false,
+            sparse: false,
         }
     }
 }

--- a/tesseract-core/src/query_ir.rs
+++ b/tesseract-core/src/query_ir.rs
@@ -23,6 +23,7 @@ pub struct QueryIr {
     pub rca: Option<RcaSql>,
     pub growth: Option<GrowthSql>,
     pub rate: Option<RateSql>,
+    pub sparse: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/tesseract-server/src/handlers/aggregate.rs
+++ b/tesseract-server/src/handlers/aggregate.rs
@@ -156,7 +156,7 @@ pub struct AggregateQueryOpt {
     debug: Option<bool>,
 //    distinct: Option<bool>,
 //    nonempty: Option<bool>,
-//    sparse: Option<bool>,
+    sparse: Option<bool>,
 }
 
 impl TryFrom<AggregateQueryOpt> for TsQuery {
@@ -234,6 +234,7 @@ impl TryFrom<AggregateQueryOpt> for TsQuery {
             .transpose()?;
 
         let debug = agg_query_opt.debug.unwrap_or(false);
+        let sparse = agg_query_opt.sparse.unwrap_or(false);
 
         // TODO: deserialize rate
         Ok(TsQuery {
@@ -251,7 +252,8 @@ impl TryFrom<AggregateQueryOpt> for TsQuery {
             rca,
             growth,
             debug,
-            rate
+            rate,
+            sparse,
         })
     }
 }

--- a/tesseract-server/src/handlers/logic_layer/shared.rs
+++ b/tesseract-server/src/handlers/logic_layer/shared.rs
@@ -140,7 +140,7 @@ pub struct LogicLayerQueryOpt {
     locale: Option<String>,
 //    distinct: Option<bool>,
 //    nonempty: Option<bool>,
-//    sparse: Option<bool>,
+    sparse: Option<bool>,
     rate: Option<String>,
 }
 
@@ -501,6 +501,7 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
         };
 
         let debug = agg_query_opt.debug.unwrap_or(false);
+        let sparse = agg_query_opt.sparse.unwrap_or(false);
 
         Ok(TsQuery {
             drilldowns,
@@ -517,7 +518,8 @@ impl TryFrom<LogicLayerQueryOpt> for TsQuery {
             growth,
             debug,
             filters,
-            rate
+            rate,
+            sparse,
         })
     }
 }


### PR DESCRIPTION
This is one potential avenue for supporting the sparse feature so that users can filter rows where all measures are null. 

Example usage:

`http://localhost:7777/data?cube=DM&drilldowns=Race&measures=Value&sparse=true`

I think another way to implement this would be to tap into the existing `query_ir.filters` functionality. One challenge there is that at the moment it looks like the comparisons/constraints structs are not generalized beyond integer operations (as `n` is an `i64`) , additionally the `sql_string` for constraints will likely need to be driver specific (i.e clickhouse uses `isNotNull(x)` versus Postgres' `x IS NOT NULL`. Down the road if/when those elements are refactored the sparse functionality could be updated accordingly, but I think this logic should do the job for now.

As always let me know your thoughts and feedback!

Fixes #134

EDIT: 

One other thing I included in this PR along the way was a bit of a refactor in certain instances where we were passing several arguments that were all directly from the `query_ir` reference. For future use, I think it might provide more flexibility to simply pass the `query_ir` reference between the functions.