### PR TITLE
Fixes bug with dimensions without default members

### DIFF
--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -207,7 +207,7 @@ impl Schema {
     ///
     /// If the function runs in negate mode, it will add or remove a ~ from the front of the default member
     /// cut string to flip the logic in order to exclude the default member from being returned in queries.
-    fn build_default_member_cuts(&self, schema_cube: &Cube, query: &Query, negate: bool) -> Result<Vec<Cut>, Error> {
+    fn build_default_member_cuts(&self, schema_cube: &Cube, query: &Query, negate: bool) -> Vec<Cut> {
         let target_dims = self.get_dims_for_default_member(schema_cube, query, negate);
         let result = target_dims.iter().map(|dim| {
             let target_hierarchy_name = match &dim.default_hierarchy {
@@ -221,21 +221,18 @@ impl Schema {
                 Some(val) => {
                     let mut new_cut_str: String = val.to_string();
                     if negate {
-                        let first_ch_opt = new_cut_str.chars().next();
-                        let first_ch = first_ch_opt.ok_or_else(|| format_err!("Expected at least one character in default member"))?;
+                        let first_ch = new_cut_str.chars().next().expect("Expected at least one character in default member");
                         new_cut_str = match first_ch {
                             '~' => new_cut_str[1..].to_string(),
                             _ => format!("~{}", new_cut_str)
                         }
+
                     }
                     Cut::from_str(&new_cut_str)
                 },
-                None => {
-                    return Err(format_err!("Bad default member"))
-                }
+                None => Err(format_err!("Skipping empty default member"))
             }
-        }).collect();
-
+        }).filter_map(Result::ok).collect();
         return result;
     }
 
@@ -386,13 +383,13 @@ impl Schema {
 
         cut_cols.extend_from_slice(&default_hierarchy_cut_cols);
 
-        let default_member_cuts_query = self.build_default_member_cuts(schema_cube, query, false)?;
+        let default_member_cuts_query = self.build_default_member_cuts(schema_cube, query, false);
         let default_member_cut_cols = self.cube_cut_cols(&cube, &default_member_cuts_query)
             .map_err(|err| format_err!("Error creating cuts for default member: {}", err))?;
         cut_cols.extend_from_slice(&default_member_cut_cols);
 
         if query.exclude_default_members {
-            let exclude_default_member_cuts_query = self.build_default_member_cuts(schema_cube, query, true)?;
+            let exclude_default_member_cuts_query = self.build_default_member_cuts(schema_cube, query, true);
             let exclude_default_member_cut_cols = self.cube_cut_cols(&cube, &exclude_default_member_cuts_query)
                 .map_err(|err| format_err!("Error creating exclude cuts for default member: {}", err))?;
             cut_cols.extend_from_slice(&exclude_default_member_cut_cols);


### PR DESCRIPTION
Not ideal, but just wanted to push this patch for now to fix an issue that causes drilldowns to fail when certain dimensions do not have a specified default member. This is meant as a break/fix patch and will take a look at reverting back to a better Vec<Cut> construction (possibly using foreach instead of map).