### PR TITLE
Added max and min aggregators

### DIFF
--- a/tesseract-clickhouse/src/sql/aggregator.rs
+++ b/tesseract-clickhouse/src/sql/aggregator.rs
@@ -32,6 +32,8 @@ pub fn agg_sql_string_pass_1(col: &str, aggregator: &Aggregator, mea_idx: usize)
         Aggregator::Sum => format!("sum({}) as m{}", col, mea_idx),
         Aggregator::Count => format!("count({}) as m{}", col, mea_idx),
         Aggregator::Average => format!("avg({}) as m{}", col, mea_idx),
+        Aggregator::Max => format!("max({}) as m{}", col, mea_idx),
+        Aggregator::Min => format!("min({}) as m{}", col, mea_idx),
         Aggregator::BasicGroupedMedian { group_aggregator, .. } => format!("{}({}) as m{}", group_aggregator, col, mea_idx),
         Aggregator::WeightedAverage { weight_column } => {
             format!("sum({0} * {1}) as m{2}_weighted_avg_num, sum({1}) as m{2}_weighted_avg_denom",
@@ -96,6 +98,8 @@ pub fn agg_sql_string_select_mea(aggregator: &Aggregator, mea_idx: usize) -> Str
         Aggregator::Sum => format!("m{0}", mea_idx),
         Aggregator::Count => format!("m{0}", mea_idx),
         Aggregator::Average => format!("m{0}", mea_idx),
+        Aggregator::Max => format!("m{0}", mea_idx),
+        Aggregator::Min => format!("m{0}", mea_idx),
         Aggregator::BasicGroupedMedian { .. } => format!("m{0}", mea_idx),
         Aggregator::WeightedAverage { .. } => {
             format!("m{0}_weighted_avg_num, m{0}_weighted_avg_denom",
@@ -145,6 +149,8 @@ pub fn agg_sql_string_pass_2(aggregator: &Aggregator, mea_idx: usize) -> String 
         Aggregator::Sum => format!("sum(m{0}) as final_m{0}", mea_idx),
         Aggregator::Count => format!("sum(m{0}) as final_m{0}", mea_idx),
         Aggregator::Average => format!("avg(m{0}) as final_m{0}", mea_idx),
+        Aggregator::Max => format!("max(m{0}) as final_m{0}", mea_idx),
+        Aggregator::Min => format!("min(m{0}) as final_m{0}", mea_idx),
         Aggregator::BasicGroupedMedian { .. } => format!("median(m{0}) as final_m{0}", mea_idx),
         Aggregator::WeightedAverage { .. } => {
             format!("(sum(m{0}_weighted_avg_num) / sum(m{0}_weighted_avg_denom)) as final_m{0}",

--- a/tesseract-clickhouse/src/sql/aggregator.rs
+++ b/tesseract-clickhouse/src/sql/aggregator.rs
@@ -225,6 +225,38 @@ mod test {
     }
 
     #[test]
+    fn max_agg() {
+        assert_eq!(
+            agg_sql_string_pass_1("col_1".into(), &Aggregator::Max, 0),
+            "max(col_1) as m0".to_owned(),
+        );
+        assert_eq!(
+            agg_sql_string_pass_2(&Aggregator::Max, 0),
+            "max(m0) as final_m0".to_owned(),
+        );
+        assert_eq!(
+            agg_sql_string_select_mea(&Aggregator::Max, 0),
+            "m0".to_owned(),
+        );
+    }
+
+    #[test]
+    fn min_agg() {
+        assert_eq!(
+            agg_sql_string_pass_1("col_1".into(), &Aggregator::Min, 0),
+            "min(col_1) as m0".to_owned(),
+        );
+        assert_eq!(
+            agg_sql_string_pass_2(&Aggregator::Min, 0),
+            "min(m0) as final_m0".to_owned(),
+        );
+        assert_eq!(
+            agg_sql_string_select_mea(&Aggregator::Min, 0),
+            "m0".to_owned(),
+        );
+    }
+
+    #[test]
     fn weighted_avg() {
         let agg = Aggregator::WeightedAverage {
             weight_column: "weight_col".into(),

--- a/tesseract-core/src/schema/aggregator.rs
+++ b/tesseract-core/src/schema/aggregator.rs
@@ -16,6 +16,10 @@ pub enum Aggregator {
     Count,
     #[serde(rename="avg")]
     Average,
+    #[serde(rename="max")]
+    Max,
+    #[serde(rename="min")]
+    Min,
     /// Median
     ///
     /// Needs two steps. It's slow because there won't be aggregation on the first step, only

--- a/tesseract-core/src/schema/metadata.rs
+++ b/tesseract-core/src/schema/metadata.rs
@@ -186,6 +186,8 @@ impl From<&Aggregator> for AggregatorMetadata {
             Aggregator::Sum => "sum".into(),
             Aggregator::Count => "count".into(),
             Aggregator::Average => "avg".into(),
+            Aggregator::Max => "max".into(),
+            Aggregator::Min => "min".into(),
             Aggregator::BasicGroupedMedian { .. } => "basic_grouped_median".into(),
             Aggregator::WeightedAverage { ..} => "weighted_average".into(),
             Aggregator::WeightedSum { ..} => "weighted_sum".into(),

--- a/tesseract-core/src/sql.rs
+++ b/tesseract-core/src/sql.rs
@@ -37,6 +37,8 @@ pub(crate) fn standard_sql(
             Aggregator::Sum => format!("sum({})", &m.column),
             Aggregator::Count => format!("count({})", &m.column),
             Aggregator::Average => format!("avg({})", &m.column),
+            Aggregator::Max => format!("max({})", &m.column),
+            Aggregator::Min => format!("min({})", &m.column),
             // median doesn't work like this
             Aggregator::BasicGroupedMedian { .. } => format!("median"),
             Aggregator::WeightedAverage {..} => format!("avg"),


### PR DESCRIPTION
Two aggregators for `max` and `min` have been added by extending code on four files. When running `cargo build` the operation has been successful.