### PR TITLE
remove default readonly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,9 +534,11 @@ dependencies = [
  "lazy_static",
  "log",
  "lz4",
+ "native-tls",
  "thiserror",
  "tokio 0.1.22",
  "tokio-timer",
+ "tokio-tls",
  "url 2.3.1",
  "uuid 0.8.2",
 ]
@@ -606,6 +608,16 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.9.9",
  "time",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1059,6 +1071,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1430,15 @@ dependencies = [
  "autocfg 1.1.0",
  "hashbrown",
  "serde",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1782,6 +1812,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1942,12 @@ dependencies = [
  "quote 1.0.21",
  "syn 1.0.103",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
@@ -2407,6 +2461,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "rent_to_own"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2522,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "scheduled-thread-pool"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,6 +2562,29 @@ name = "scratch"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
+name = "security-framework"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2795,6 +2890,20 @@ dependencies = [
  "quote 1.0.21",
  "syn 1.0.103",
  "unicode-xid 0.2.4",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall 0.2.16",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3181,6 +3290,17 @@ dependencies = [
  "futures",
  "slab",
  "tokio-executor",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
+dependencies = [
+ "futures",
+ "native-tls",
+ "tokio-io",
 ]
 
 [[package]]

--- a/tesseract-clickhouse/Cargo.toml
+++ b/tesseract-clickhouse/Cargo.toml
@@ -10,7 +10,6 @@ failure = "0.1.2"
 futures = "0.1.25"
 itertools = "0.8.0"
 log = "0.4.3"
-regex = "1"
 
 [dependencies.tesseract-core]
 path = "../tesseract-core"

--- a/tesseract-clickhouse/src/lib.rs
+++ b/tesseract-clickhouse/src/lib.rs
@@ -6,8 +6,6 @@ use log::*;
 use std::time::{Duration, Instant};
 use tesseract_core::{Backend, DataFrame, QueryIr};
 
-use regex::Regex;
-
 mod df;
 mod sql;
 
@@ -24,20 +22,12 @@ pub struct Clickhouse {
 
 impl Clickhouse {
     pub fn from_url(url: &str) -> Result<Self, Error> {
-        let rg = Regex::new(r"(?:readonly=)(?P<id>[0-2])").unwrap();
-
         let options = format!("tcp://{}", url).parse::<Options>()?;
 
-        let options = options.readonly(
-            match rg.captures(url) {
-                Some(readonly_option) => {
-                    let rg_match = readonly_option.name("id").expect("Could not parse a value for readonly").as_str();
-                    let num_match = rg_match.parse::<u8>().expect(&format!("Failed to parse {} into a numeric value", rg_match));
-                    Some(num_match)
-                },
-                None => Some(1)
-            }
-        ).ping_timeout(Duration::from_millis(PING_TIMEOUT));
+        let options = options
+            // Ping timeout is necessary, because under heavy load (100 requests
+            // simultaneously, each one taking 5s ordinarily) the client will timeout.
+            .ping_timeout(Duration::from_millis(PING_TIMEOUT));
 
         let pool = Pool::new(options);
 


### PR DESCRIPTION
- remove default `readonly` setting, deprecated option in newer versions of Clickohuse-server